### PR TITLE
replace "this library" by "Colors.jl"

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The available colorspaces are described in detail in ColorTypes; briefly, the de
 
 Parse a [CSS color specification](https://developer.mozilla.org/en-US/docs/CSS/color). It will
 parse any CSS color syntax with the exception of `transparent`, `rgba()`,
-`hsla()` (since this library has no notion of transparency), and `currentColor`.
+`hsla()` (since `Colors.jl` has no notion of transparency), and `currentColor`.
 
 All CSS/SVG named colors are supported, in addition to X11 named colors, when
 their definitions do not clash with SVG.


### PR DESCRIPTION
I read this to mean `hsla()` has no notion of transparency at first, this phrasing is less ambiguous.