### PR TITLE
Second renaming, add Colorant string macro, drop Graphics dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ The available colorspaces are described in detail in ColorTypes; briefly, the de
 
 `color(desc::String)`
 
-Parse a [CSS color specification](https://developer.mozilla.org/en-US/docs/CSS/color). It will
-parse any CSS color syntax with the exception of `transparent`, `rgba()`,
-`hsla()` (since this library has no notion of transparency), and `currentColor`.
+Parse a [CSS color specification](https://developer.mozilla.org/en-US/docs/CSS/color). It will parse any CSS color syntax with the exception of `currentColor`.
 
 All CSS/SVG named colors are supported, in addition to X11 named colors, when
 their definitions do not clash with SVG.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The available colorspaces are described in detail in ColorTypes; briefly, the de
 ## Color Parsing
 
 ```jl
-c = Colorant"red"
+c = colorant"red"
 c = parse(Colorant, "red")
 ```
 
@@ -60,7 +60,7 @@ Returns a `RGB{U8}` color, unless:
     - `"hsla(h,s,l,a)"` was used, in which case an `HSLA` color;
     - a specific `Colorant` type was specified in the first argument
 
-When writing functions the `Colorant"red"` version is preferred, because
+When writing functions the `colorant"red"` version is preferred, because
 the slow step runs when the code is parsed (i.e., during compilation
 rather than run-time).
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ The available colorspaces are described in detail in ColorTypes; briefly, the de
 
 ## Color Parsing
 
-`color(desc::String)`
+```jl
+c = Color"red"
+c = parse(Color, "red")
+```
 
 Parse a [CSS color specification](https://developer.mozilla.org/en-US/docs/CSS/color). It will parse any CSS color syntax with the exception of `currentColor`.
 
@@ -53,6 +56,10 @@ their definitions do not clash with SVG.
 
 A `RGB` color is returned, except when the `hsl()` syntax is used, which returns
 a `HSL` value.
+
+When writing functions the `Color"red"` version is preferred, because
+the slow step runs when the code is parsed (i.e., during compilation
+rather than run-time).
 
 ## CIE Standard Observer
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ The available colorspaces are described in detail in ColorTypes; briefly, the de
 ## Color Parsing
 
 ```jl
-c = Color"red"
-c = parse(Color, "red")
+c = Colorant"red"
+c = parse(Colorant, "red")
 ```
 
 Parse a [CSS color specification](https://developer.mozilla.org/en-US/docs/CSS/color). It will parse any CSS color syntax with the exception of `currentColor`.
@@ -54,10 +54,13 @@ Parse a [CSS color specification](https://developer.mozilla.org/en-US/docs/CSS/c
 All CSS/SVG named colors are supported, in addition to X11 named colors, when
 their definitions do not clash with SVG.
 
-A `RGB` color is returned, except when the `hsl()` syntax is used, which returns
-a `HSL` value.
+Returns a `RGB{U8}` color, unless:
+    - `"hsl(h,s,l)"` was used, in which case an `HSL` color;
+    - `"rgba(r,g,b,a)"` was used, in which case an `RGBA` color;
+    - `"hsla(h,s,l,a)"` was used, in which case an `HSLA` color;
+    - a specific `Colorant` type was specified in the first argument
 
-When writing functions the `Color"red"` version is preferred, because
+When writing functions the `Colorant"red"` version is preferred, because
 the slow step runs when the code is parsed (i.e., during compilation
 rather than run-time).
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,5 +2,4 @@ julia 0.3
 ColorTypes
 FixedPointNumbers
 Compat 0.2
-Graphics 0.1
 Reexport

--- a/images/GenerateImages.jl
+++ b/images/GenerateImages.jl
@@ -1,5 +1,5 @@
-using Color
-using Color, ColorBrewer
+using Colors
+using Colors, ColorBrewer
 
 function out_image(name, color_list)
   total_width = 12.

--- a/images/draw_swatches.jl
+++ b/images/draw_swatches.jl
@@ -1,6 +1,6 @@
 #!/Applications/Julia-0.3.9.app/Contents/Resources/julia/bin/julia
 
-using Color
+using Colors
 
 function compare_colors(color_a, color_b)
     # compare two colors, looking just at their LUV luminance values
@@ -28,7 +28,7 @@ end
 function make_color_table(image_width, image_height, output_file)
     # prepare synonym lists
     synonyms = Dict{Tuple, Array}()
-    for color in Color.color_names
+    for color in Colors.color_names
         col_name  = color[1]
         col_value = color[2]
         if haskey(synonyms, col_value)

--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -17,7 +17,7 @@ end
 
 # Additional exports, not exported by ColorTypes
 export weighted_color_mean,
-       hex, @Colorant_str,
+       hex, @colorant_str,
        protanopic, deuteranopic, tritanopic,
        distinguishable_colors, whitebalance,
        colordiff, DE_2000, DE_94, DE_JPC79, DE_CMC, DE_BFD, DE_AB, DE_DIN99, DE_DIN99d, DE_DIN99o,

--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -23,7 +23,7 @@ end
 
 # Additional exports, not exported by ColorTypes
 export weighted_color_mean,
-       hex,
+       hex, @Colorant_str,
        protanopic, deuteranopic, tritanopic,
        distinguishable_colors, whitebalance,
        colordiff, DE_2000, DE_94, DE_JPC79, DE_CMC, DE_BFD, DE_AB, DE_DIN99, DE_DIN99d, DE_DIN99o,

--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -5,8 +5,8 @@ module Colors
 using FixedPointNumbers, ColorTypes, Reexport, Compat
 @reexport using ColorTypes
 
-typealias AbstractGray{T} OpaqueColor{T,1}
-typealias OpaqueColor3{T} OpaqueColor{T,3}
+typealias AbstractGray{T} Color{T,1}
+typealias Color3{T} Color{T,3}
 
 import Base: ==, +, -, *, /
 import Base: convert, eltype, hex, isless, linspace, show, typemin, typemax, writemime

--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -11,12 +11,6 @@ typealias Color3{T} Color{T,3}
 import Base: ==, +, -, *, /
 import Base: convert, eltype, hex, isless, linspace, show, typemin, typemax, writemime
 
-if VERSION < v"0.4.0-dev+3275"
-    import Base.Graphics: set_source, set_source_rgb, GraphicsContext
-else
-    import Graphics: set_source, set_source_rgb, GraphicsContext
-end
-
 if VERSION < v"0.4.0-dev"
     using Docile
 end

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -6,11 +6,11 @@
 *(c::Number, a::XYZ) = XYZ(c*a.x, c*a.y, c*a.z)
 
 #Most color spaces are nonlinear, so do the arithmetic in XYZ and convert back
-+{T<:OpaqueColor}(a::T, b::T) = convert(T, convert(XYZ, a) + convert(XYZ, b))
-*{T<:OpaqueColor}(c::Number, a::T) = convert(T, c * convert(XYZ, a))
-*{T<:OpaqueColor}(c::Number, a::T) = convert(T, c * convert(XYZ, a))
++{T<:Color}(a::T, b::T) = convert(T, convert(XYZ, a) + convert(XYZ, b))
+*{T<:Color}(c::Number, a::T) = convert(T, c * convert(XYZ, a))
+*{T<:Color}(c::Number, a::T) = convert(T, c * convert(XYZ, a))
 
-/(a::OpaqueColor, c::Number) = *(1/c, a)
+/(a::Color, c::Number) = *(1/c, a)
 
 # Algorithms relating to color processing and generation
 
@@ -37,7 +37,7 @@ Args:
 Returns:
   A whitebalanced color.
 """ ->
-function whitebalance{T <: OpaqueColor}(c::T, src_white::OpaqueColor, ref_white::OpaqueColor)
+function whitebalance{T <: Color}(c::T, src_white::Color, ref_white::Color)
     c_lms = convert(LMS, c)
     src_wp = convert(LMS, src_white)
     dest_wp = convert(LMS, ref_white)
@@ -89,7 +89,7 @@ long-wavelength photopigment).  `c` is the input color; the optional
 argument `p` is the fraction of photopigment loss, in the range 0 (no
 loss) to 1 (complete loss).
 """ ->
-function protanopic{T <: OpaqueColor}(q::T, p, neutral::LMS)
+function protanopic{T <: Color}(q::T, p, neutral::LMS)
     q = convert(LMS, q)
     anchor_wavelen = q.s / q.m < neutral.s / neutral.m ? 575 : 475
     anchor = colormatch(anchor_wavelen)
@@ -110,7 +110,7 @@ end
 Convert a color to simulate deuteranopic color deficiency (lack of the
 middle-wavelength photopigment).  See the description of `protanopic` for detail about the arguments.
 """ ->
-function deuteranopic{T <: OpaqueColor}(q::T, p, neutral::LMS)
+function deuteranopic{T <: Color}(q::T, p, neutral::LMS)
     q = convert(LMS, q)
     anchor_wavelen = q.s / q.l < neutral.s / neutral.l ? 575 : 475
     anchor = colormatch(anchor_wavelen)
@@ -132,7 +132,7 @@ Convert a color to simulate tritanopic color deficiency (lack of the
 short-wavelength photogiment).  See `protanopic` for more detail about
 the arguments.
 """ ->
-function tritanopic{T <: OpaqueColor}(q::T, p, neutral::LMS)
+function tritanopic{T <: Color}(q::T, p, neutral::LMS)
     q = convert(LMS, q)
     anchor_wavelen = q.m / q.l < neutral.m / neutral.l ? 660 : 485
     anchor = colormatch(anchor_wavelen)
@@ -146,19 +146,19 @@ function tritanopic{T <: OpaqueColor}(q::T, p, neutral::LMS)
 end
 
 
-protanopic(c::OpaqueColor, p)   = protanopic(c, p, default_brettel_neutral)
-deuteranopic(c::OpaqueColor, p) = deuteranopic(c, p, default_brettel_neutral)
-tritanopic(c::OpaqueColor, p)   = tritanopic(c, p, default_brettel_neutral)
+protanopic(c::Color, p)   = protanopic(c, p, default_brettel_neutral)
+deuteranopic(c::Color, p) = deuteranopic(c, p, default_brettel_neutral)
+tritanopic(c::Color, p)   = tritanopic(c, p, default_brettel_neutral)
 
-protanopic(c::OpaqueColor)   = protanopic(c, 1.0)
-deuteranopic(c::OpaqueColor) = deuteranopic(c, 1.0)
-tritanopic(c::OpaqueColor)   = tritanopic(c, 1.0)
+protanopic(c::Color)   = protanopic(c, 1.0)
+deuteranopic(c::Color) = deuteranopic(c, 1.0)
+tritanopic(c::Color)   = tritanopic(c, 1.0)
 
-@vectorize_1arg OpaqueColor protanopic
-@vectorize_1arg OpaqueColor deuteranopic
-@vectorize_1arg OpaqueColor tritanopic
+@vectorize_1arg Color protanopic
+@vectorize_1arg Color deuteranopic
+@vectorize_1arg Color tritanopic
 
-# MSC - Most Saturated Color for given hue h
+# MSC - Most Saturated Colorant for given hue h
 # ---------------------
 
 @doc """

--- a/src/colormaps.jl
+++ b/src/colormaps.jl
@@ -30,7 +30,7 @@ Keyword arguments:
 Returns:
   A `Vector` of colors of length `n`, of the type specified in `seed`.
 """ ->
-function distinguishable_colors{T<:OpaqueColor}(n::Integer,
+function distinguishable_colors{T<:Color}(n::Integer,
                             seed::AbstractVector{T};
                             transform::Function = identity,
                             lchoices::AbstractVector = linspace(0, 100, 15),
@@ -81,12 +81,12 @@ function distinguishable_colors{T<:OpaqueColor}(n::Integer,
 end
 
 
-distinguishable_colors(n::Integer, seed::OpaqueColor; kwargs...) = distinguishable_colors(n, [seed]; kwargs...)
+distinguishable_colors(n::Integer, seed::Color; kwargs...) = distinguishable_colors(n, [seed]; kwargs...)
 distinguishable_colors(n::Integer; kwargs...) = distinguishable_colors(n, Array(RGB{U8},0); kwargs...)
 
 @deprecate distinguishable_colors(n::Integer,
                                 transform::Function,
-                                seed::OpaqueColor,
+                                seed::Color,
                                 ls::Vector{Float64},
                                 cs::Vector{Float64},
                                 hs::Vector{Float64})    distinguishable_colors(n, [seed], transform = transform, lchoices = ls, cchoices = cs, hchoices = hs)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -6,12 +6,12 @@
 #     _convert(::Type{Cdest}, ::Type{Odest}, ::Type{Osrc}, c)
 #     _convert(::Type{Cdest}, ::Type{Odest}, ::Type{Osrc}, c, alpha)
 # Here are the argument types:
-# - Cdest may be any concrete Color type. For parametric paint types
+# - Cdest may be any concrete Color{T,N} type. For parametric Color types
 #   it _always_ has the desired element type (e.g., Float32), so it's
 #   safe to dispatch on Cdest{T}.
-# - Odest and Osrc are OpaqueColor subtypes, i.e., things like RGB
+# - Odest and Osrc are Color subtypes, i.e., things like RGB
 #   or HSV. They have no element type.
-# - c is the Color object you wish to convert.
+# - c is the Colorant object you wish to convert.
 # - alpha, if present, is a user-supplied alpha value (to be used in
 #   place of any default alpha or alpha present in c).
 #
@@ -37,21 +37,21 @@
 
 function ColorTypes._convert{Cdest<:TransparentColor,Odest,Osrc}(::Type{Cdest}, ::Type{Odest}, ::Type{Osrc}, p, alpha)
     # Convert the base color
-    c = cnvt(opaquetype(Cdest), opaquecolor(p))
+    c = cnvt(color_type(Cdest), color(p))
     # Append the alpha
     ColorTypes._convert(Cdest, Odest, Odest, c, alpha)
 end
 function ColorTypes._convert{Cdest<:TransparentColor,Odest,Osrc}(::Type{Cdest}, ::Type{Odest}, ::Type{Osrc}, p)
-    c = cnvt(opaquetype(Cdest), opaquecolor(p))
+    c = cnvt(color_type(Cdest), color(p))
     ColorTypes._convert(Cdest, Odest, Odest, c, alpha(p))
 end
 
-ColorTypes._convert{Cdest<:OpaqueColor,Odest,Osrc}(::Type{Cdest}, ::Type{Odest}, ::Type{Osrc}, c) = cnvt(Cdest, c)
+ColorTypes._convert{Cdest<:Color,Odest,Osrc}(::Type{Cdest}, ::Type{Odest}, ::Type{Osrc}, c) = cnvt(Cdest, c)
 
 
 # Conversions from grayscale
 # --------------------------
-cnvt{C<:OpaqueColor3}(::Type{C}, g::AbstractGray)  = cnvt(C, convert(RGB{eltype(C)}, g))
+cnvt{C<:Color3}(::Type{C}, g::AbstractGray)  = cnvt(C, convert(RGB{eltype(C)}, g))
 
 
 macro mul3x3(T, M, c1, c2, c3)
@@ -162,7 +162,7 @@ end
 
 cnvt{CV<:AbstractRGB}(::Type{CV}, c::LCHab)  = cnvt(CV, convert(Lab{eltype(c)}, c))
 cnvt{CV<:AbstractRGB}(::Type{CV}, c::LCHuv)  = cnvt(CV, convert(Luv{eltype(c)}, c))
-cnvt{CV<:AbstractRGB}(::Type{CV}, c::OpaqueColor3)    = cnvt(CV, convert(XYZ{eltype(c)}, c))
+cnvt{CV<:AbstractRGB}(::Type{CV}, c::Color3)    = cnvt(CV, convert(XYZ{eltype(c)}, c))
 
 cnvt{CV<:AbstractRGB{Ufixed8}}(::Type{CV}, c::RGB24) = CV(Ufixed8(c.color&0x00ff0000>>>16,0), Ufixed8(c.color&0x0000ff00>>>8,0), Ufixed8(c.color&0x000000ff,0))
 cnvt{CV<:AbstractRGB}(::Type{CV}, c::RGB24) = CV((c.color&0x00ff0000>>>16)/255, ((c.color&0x0000ff00)>>>8)/255, (c.color&0x000000ff)/255)
@@ -200,7 +200,7 @@ function cnvt{T}(::Type{HSV{T}}, c::AbstractRGB)
 end
 
 
-cnvt{T}(::Type{HSV{T}}, c::OpaqueColor3) = cnvt(HSV{T}, convert(RGB{T}, c))
+cnvt{T}(::Type{HSV{T}}, c::Color3) = cnvt(HSV{T}, convert(RGB{T}, c))
 
 
 # Everything to HSL
@@ -238,7 +238,7 @@ function cnvt{T}(::Type{HSL{T}}, c::AbstractRGB)
 end
 
 
-cnvt{T}(::Type{HSL{T}}, c::OpaqueColor3) = cnvt(HSL{T}, convert(RGB{T}, c))
+cnvt{T}(::Type{HSL{T}}, c::Color3) = cnvt(HSL{T}, convert(RGB{T}, c))
 
 
 # Everything to HSI
@@ -260,7 +260,7 @@ function cnvt{T}(::Type{HSI{T}}, c::AbstractRGB)
     HSI{T}(h, s, i)
 end
 
-cnvt{T}(::Type{HSI{T}}, c::OpaqueColor3) = cnvt(HSI{T}, convert(RGB{T}, c))
+cnvt{T}(::Type{HSI{T}}, c::Color3) = cnvt(HSI{T}, convert(RGB{T}, c))
 
 # Everything to XYZ
 # -----------------
@@ -395,7 +395,7 @@ function cnvt{T}(::Type{xyY{T}}, c::XYZ)
 
 end
 
-cnvt{T}(::Type{xyY{T}}, c::OpaqueColor3) = cnvt(xyY{T}, convert(XYZ{T}, c))
+cnvt{T}(::Type{xyY{T}}, c::Color3) = cnvt(xyY{T}, convert(XYZ{T}, c))
 
 
 
@@ -513,7 +513,7 @@ function cnvt{T}(::Type{Lab{T}}, c::DIN99o)
 end
 
 
-cnvt{T}(::Type{Lab{T}}, c::OpaqueColor3) = cnvt(Lab{T}, convert(XYZ{T}, c))
+cnvt{T}(::Type{Lab{T}}, c::Color3) = cnvt(Lab{T}, convert(XYZ{T}, c))
 
 
 # Everything to Luv
@@ -546,7 +546,7 @@ function cnvt{T}(::Type{Luv{T}}, c::LCHuv)
 end
 
 
-cnvt{T}(::Type{Luv{T}}, c::OpaqueColor3) = cnvt(Luv{T}, convert(XYZ{T}, c))
+cnvt{T}(::Type{Luv{T}}, c::Color3) = cnvt(Luv{T}, convert(XYZ{T}, c))
 
 
 # Everything to LCHuv
@@ -560,7 +560,7 @@ function cnvt{T}(::Type{LCHuv{T}}, c::Luv)
 end
 
 
-cnvt{T}(::Type{LCHuv{T}}, c::OpaqueColor3) = cnvt(LCHuv{T}, convert(Luv{T}, c))
+cnvt{T}(::Type{LCHuv{T}}, c::Color3) = cnvt(LCHuv{T}, convert(Luv{T}, c))
 
 
 # Everything to LCHab
@@ -574,7 +574,7 @@ function cnvt{T}(::Type{LCHab{T}}, c::Lab)
 end
 
 
-cnvt{T}(::Type{LCHab{T}}, c::OpaqueColor3) = cnvt(LCHab{T}, convert(Lab{T}, c))
+cnvt{T}(::Type{LCHab{T}}, c::Color3) = cnvt(LCHab{T}, convert(Lab{T}, c))
 
 
 # Everything to DIN99
@@ -626,7 +626,7 @@ function cnvt{T}(::Type{DIN99{T}}, c::Lab)
 end
 
 
-cnvt{T}(::Type{DIN99{T}}, c::OpaqueColor3) = cnvt(DIN99{T}, convert(Lab{T}, c))
+cnvt{T}(::Type{DIN99{T}}, c::Color3) = cnvt(DIN99{T}, convert(Lab{T}, c))
 
 
 # Everything to DIN99d
@@ -660,7 +660,7 @@ function cnvt{T}(::Type{DIN99d{T}}, c::XYZ{T})
 end
 
 
-cnvt{T}(::Type{DIN99d{T}}, c::OpaqueColor3) = cnvt(DIN99d{T}, convert(XYZ{T}, c))
+cnvt{T}(::Type{DIN99d{T}}, c::Color3) = cnvt(DIN99d{T}, convert(XYZ{T}, c))
 
 
 # Everything to DIN99o
@@ -701,7 +701,7 @@ function cnvt{T}(::Type{DIN99o{T}}, c::Lab)
 end
 
 
-cnvt{T}(::Type{DIN99o{T}}, c::OpaqueColor3) = cnvt(DIN99o{T}, convert(Lab{T}, c))
+cnvt{T}(::Type{DIN99o{T}}, c::Color3) = cnvt(DIN99o{T}, convert(Lab{T}, c))
 
 
 # Everything to LMS
@@ -727,7 +727,7 @@ function cnvt{T}(::Type{LMS{T}}, c::XYZ)
 end
 
 
-cnvt{T}(::Type{LMS{T}}, c::OpaqueColor3) = cnvt(LMS{T}, convert(XYZ{T}, c))
+cnvt{T}(::Type{LMS{T}}, c::Color3) = cnvt(LMS{T}, convert(XYZ{T}, c))
 
 # Everything to YIQ
 # -----------------
@@ -743,7 +743,7 @@ function cnvt{T}(::Type{YIQ{T}}, c::AbstractRGB)
            0.211456*red(rgb)-0.522591*green(rgb)+0.311135*blue(rgb))
 end
 
-cnvt{T}(::Type{YIQ{T}}, c::OpaqueColor3) = cnvt(YIQ{T}, convert(RGB{T}, c))
+cnvt{T}(::Type{YIQ{T}}, c::Color3) = cnvt(YIQ{T}, convert(RGB{T}, c))
 
 
 # Everything to YCbCr
@@ -760,7 +760,7 @@ function cnvt{T}(::Type{YCbCr{T}}, c::AbstractRGB)
              128+112*red(rgb)-93.786*green(rgb)-18.214*blue(rgb))
 end
 
-cnvt{T}(::Type{YCbCr{T}}, c::OpaqueColor3) = cnvt(YCbCr{T}, convert(RGB{T}, c))
+cnvt{T}(::Type{YCbCr{T}}, c::Color3) = cnvt(YCbCr{T}, convert(RGB{T}, c))
 
 # Everything to RGB24
 # -------------------
@@ -770,7 +770,7 @@ convert(::Type{RGB24}, c::AbstractRGB) = RGB24(round(UInt32, 255*red(c))<<16 +
                                                round(UInt32, 255*green(c))<<8 +
                                                round(UInt32, 255*blue(c)))
 
-convert(::Type{RGB24}, c::OpaqueColor) = convert(RGB24, convert(RGB{Ufixed8}, c))
+convert(::Type{RGB24}, c::Color) = convert(RGB24, convert(RGB{Ufixed8}, c))
 
 
 # To ARGB32
@@ -780,8 +780,8 @@ convert{CV<:AbstractRGB{Ufixed8}}(::Type{ARGB32}, c::TransparentColor{CV}) =
     ARGB32(red(c), green(c), blue(c), alpha(c))
 convert(::Type{ARGB32}, c::TransparentColor) =
     ARGB32(convert(RGB24, c).color | round(UInt32, 255*alpha(c))<<24)
-convert(::Type{ARGB32}, c::OpaqueColor) = ARGB32(convert(RGB24, c).color | 0xff000000)
-convert(::Type{ARGB32}, c::OpaqueColor, alpha) = ARGB32(convert(RGB24, c).color | round(UInt32, 255*alpha)<<24)
+convert(::Type{ARGB32}, c::Color) = ARGB32(convert(RGB24, c).color | 0xff000000)
+convert(::Type{ARGB32}, c::Color, alpha) = ARGB32(convert(RGB24, c).color | round(UInt32, 255*alpha)<<24)
 
 # To Gray
 # -------

--- a/src/differences.jl
+++ b/src/differences.jl
@@ -98,7 +98,7 @@ pow7(x) = (y = x*x*x; y*y*x)
 const twentyfive7 = 25^7
 
 # Delta E 2000
-function colordiff(ai::OpaqueColor, bi::OpaqueColor, m::DE_2000)
+function colordiff(ai::Color, bi::Color, m::DE_2000)
     # Ensure that the input values are in L*a*b* space
     a_Lab = convert(Lab, ai)
     b_Lab = convert(Lab, bi)
@@ -161,7 +161,7 @@ function colordiff(ai::OpaqueColor, bi::OpaqueColor, m::DE_2000)
 end
 
 # Delta E94
-function colordiff(ai::OpaqueColor, bi::OpaqueColor, m::DE_94)
+function colordiff(ai::Color, bi::Color, m::DE_94)
 
     a = convert(LCHab, ai)
     b = convert(LCHab, bi)
@@ -191,7 +191,7 @@ function colordiff(ai::OpaqueColor, bi::OpaqueColor, m::DE_94)
 end
 
 # Metric form of jpc79 color difference equation (mostly obsolete)
-function colordiff(ai::OpaqueColor, bi::OpaqueColor, m::DE_JPC79)
+function colordiff(ai::Color, bi::Color, m::DE_JPC79)
 
     # Convert directly into LCh
     a = convert(LCHab, ai)
@@ -241,7 +241,7 @@ end
 
 
 # Metric form of the cmc color difference
-function colordiff(ai::OpaqueColor, bi::OpaqueColor, m::DE_CMC)
+function colordiff(ai::Color, bi::Color, m::DE_CMC)
 
     # Convert directly into LCh
     a = convert(LCHab, ai)
@@ -296,7 +296,7 @@ function colordiff(ai::OpaqueColor, bi::OpaqueColor, m::DE_CMC)
 end
 
 # The BFD color difference equation
-function colordiff(ai::OpaqueColor, bi::OpaqueColor, m::DE_BFD)
+function colordiff(ai::Color, bi::Color, m::DE_BFD)
 
     # We have to start back in XYZ because BFD uses a different L equation
     a_XYZ = convert(XYZ, ai, m.wp)
@@ -356,7 +356,7 @@ function colordiff(ai::OpaqueColor, bi::OpaqueColor, m::DE_BFD)
 end
 
 # Delta E*ab (the original)
-function colordiff(ai::OpaqueColor, bi::OpaqueColor, m::DE_AB)
+function colordiff(ai::Color, bi::Color, m::DE_AB)
 
     # Convert directly into L*a*b*
     a = convert(Lab, ai)
@@ -376,7 +376,7 @@ end
 #
 # Returns:
 #   The DIN99 color difference metric evaluated between a and b.
-function colordiff(ai::OpaqueColor, bi::OpaqueColor, m::DE_DIN99)
+function colordiff(ai::Color, bi::Color, m::DE_DIN99)
 
     a = convert(DIN99, ai)
     b = convert(DIN99, bi)
@@ -386,7 +386,7 @@ function colordiff(ai::OpaqueColor, bi::OpaqueColor, m::DE_DIN99)
 end
 
 # A color difference formula for the DIN99d uniform color space
-function colordiff(ai::OpaqueColor, bi::OpaqueColor, m::DE_DIN99d)
+function colordiff(ai::Color, bi::Color, m::DE_DIN99d)
 
     a = convert(DIN99d, ai)
     b = convert(DIN99d, bi)
@@ -396,7 +396,7 @@ function colordiff(ai::OpaqueColor, bi::OpaqueColor, m::DE_DIN99d)
 end
 
 # The DIN99o color difference metric evaluated between colors a and b.
-function colordiff(ai::OpaqueColor, bi::OpaqueColor, m::DE_DIN99o)
+function colordiff(ai::Color, bi::Color, m::DE_DIN99o)
 
     a = convert(DIN99o, ai)
     b = convert(DIN99o, bi)
@@ -415,4 +415,4 @@ colors `a` and `b`.  Optionally, a `metric` may be supplied, chosen
 among `DE_2000` (the default), `DE_94`, `DE_JPC79`, `DE_CMC`,
 `DE_BFD`, `DE_AB`, `DE_DIN99`, `DE_DIN99d`, `DE_DIN99o`.
 """ ->
-colordiff(ai::OpaqueColor, bi::OpaqueColor) = colordiff(ai::OpaqueColor, bi::OpaqueColor, DE_2000())
+colordiff(ai::Color, bi::Color) = colordiff(ai::Color, bi::Color, DE_2000())

--- a/src/display.jl
+++ b/src/display.jl
@@ -1,7 +1,7 @@
 # Displaying color swatches
 # -------------------------
 
-function writemime(io::IO, ::MIME"image/svg+xml", c::OpaqueColor)
+function writemime(io::IO, ::MIME"image/svg+xml", c::Color)
     write(io,
         """
         <?xml version"1.0" encoding="UTF-8"?>
@@ -15,7 +15,7 @@ function writemime(io::IO, ::MIME"image/svg+xml", c::OpaqueColor)
         """)
 end
 
-function writemime{T <: OpaqueColor}(io::IO, ::MIME"image/svg+xml",
+function writemime{T <: Color}(io::IO, ::MIME"image/svg+xml",
                                      cs::AbstractVecOrMat{T})
     m,n = ndims(cs) == 2 ? size(cs) : (1,length(cs))
 

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -134,3 +134,14 @@ function Base.parse(::Type{Colorant}, desc::AbstractString)
 end
 
 Base.parse{C<:Colorant}(::Type{C}, desc) = convert(C, parse(Colorant, desc))::C
+
+macro Colorant_str(ex)
+    isa(ex, AbstractString) || error("Colorant macro only works with literal strings")
+    col = parse(Colorant, ex)
+    :($col)
+end
+
+@noinline function ColorTypes.color(str::AbstractString)
+    Base.depwarn("color(\"$str\") is deprecated, use Colorant\"$str\" or parse(Colorant, \"$str\")", :color)
+    parse(Colorant, str)
+end

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -135,13 +135,13 @@ end
 
 Base.parse{C<:Colorant}(::Type{C}, desc) = convert(C, parse(Colorant, desc))::C
 
-macro Colorant_str(ex)
-    isa(ex, AbstractString) || error("Colorant macro only works with literal strings")
+macro colorant_str(ex)
+    isa(ex, AbstractString) || error("colorant requires literal strings")
     col = parse(Colorant, ex)
     :($col)
 end
 
 @noinline function ColorTypes.color(str::AbstractString)
-    Base.depwarn("color(\"$str\") is deprecated, use Colorant\"$str\" or parse(Colorant, \"$str\")", :color)
+    Base.depwarn("color(\"$str\") is deprecated, use colorant\"$str\" or parse(Colorant, \"$str\")", :color)
     parse(Colorant, str)
 end

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -48,7 +48,7 @@ end
 
 
 @doc """
-    parse(Color, desc)
+    parse(Colorant, desc)
 
 Parse a color description.
 
@@ -60,7 +60,7 @@ slightly different than W3C named colors in some cases), "rgb()", "hsl()",
 "#RGB", and "#RRGGBB' syntax.
 
 Args:
-- `Color`: literal "Color" will parse according to the `desc`
+- `Colorant`: literal "Colorant" will parse according to the `desc`
 string (usually returning an `RGB`); any more specific choice will
 return a color of the specified type.
 - `desc`: A color name or description.
@@ -70,9 +70,9 @@ Returns:
     - "hsl(h,s,l)" was used, in which case an `HSL` color;
     - "rgba(r,g,b,a)" was used, in which case an `RGBA` color;
     - "hsla(h,s,l,a)" was used, in which case an `HSLA` color;
-    - a specific `Color` type was specified in the first argument
+    - a specific `Colorant` type was specified in the first argument
 """ ->
-function Base.parse(::Type{Color}, desc::AbstractString)
+function Base.parse(::Type{Colorant}, desc::AbstractString)
     desc_ = replace(desc, " ", "")
     mat = match(col_pat_hex2, desc_)
     if mat != nothing
@@ -133,4 +133,4 @@ function Base.parse(::Type{Color}, desc::AbstractString)
     return RGB{U8}(c[1] / 255, c[2] / 255, c[3] / 255)
 end
 
-Base.parse{C<:Color}(::Type{C}, desc) = convert(C, parse(Color, desc))::C
+Base.parse{C<:Colorant}(::Type{C}, desc) = convert(C, parse(Colorant, desc))::C

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -32,13 +32,6 @@ end
 hex(c::Color) = hex(convert(RGB, c))
 hex(c::Colorant) = hex(convert(ARGB, c))
 
-
-# set source color as a Color
-function set_source(gc::GraphicsContext, c::Color)
-    rgb = convert(RGB, c)
-    set_source_rgb(gc, rgb.r, rgb.g, rgb.b)
-end
-
 # weighted_color_mean(w1, c1, c2) gives a mean color "w1*c1 + (1-w1)*c2".
 for (T,a,b,c) in ((:RGB,:r,:g,:b), (:HSV,:h,:s,:v), (:HSL,:h,:s,:l),
                   (:XYZ,:x,:y,:z), (:Lab,:l,:a,:b), (:LCHab,:l,:c,:h),

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -29,12 +29,12 @@ function hex(c::ARGB)
              round(Int, lerp(blue(c), 0.0, 255.0)))
 end
 
-hex(c::OpaqueColor) = hex(convert(RGB, c))
-hex(c::Color) = hex(convert(ARGB, c))
+hex(c::Color) = hex(convert(RGB, c))
+hex(c::Colorant) = hex(convert(ARGB, c))
 
 
-# set source color as a OpaqueColor
-function set_source(gc::GraphicsContext, c::OpaqueColor)
+# set source color as a Color
+function set_source(gc::GraphicsContext, c::Color)
     rgb = convert(RGB, c)
     set_source_rgb(gc, rgb.r, rgb.g, rgb.b)
 end
@@ -61,12 +61,12 @@ weighted_color_mean(w1::Real, c1::RGB24, c2::RGB24) =
     convert(RGB24, weighted_color_mean(w1, convert(RGB, c1), convert(RGB, c2)))
 
 @doc """
-    linspace(c1::OpaqueColor, c2::OpaqueColor, n=100)
+    linspace(c1::Color, c2::Color, n=100)
 
 Generates `n` colors in a linearly interpolated ramp from `c1` to
 `c2`, inclusive, returning an `Array` of colors.
 """ ->
-function linspace{T<:OpaqueColor}(c1::T, c2::T, n=100)
+function linspace{T<:Color}(c1::T, c2::T, n=100)
     a = Array(T, convert(Int, n))
     if n == 1
         a[1] = c1

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -4,16 +4,19 @@ import ColorTypes: eltype_default
 
 # Color parsing
 const redU8 = parse(Colorant, "red")
+@test Colorant"red" == redU8
 @test isa(redU8, RGB{U8})
 @test redU8 == RGB(1,0,0)
 const redF64 = convert(RGB{Float64}, redU8)
 @test parse(RGB{Float64}, "red") === RGB{Float64}(1,0,0)
 @test isa(parse(HSV, "blue"), HSV)
 @test parse(Colorant, "rgb(55,217,127)") === RGB{U8}(0x37uf8,0xd9uf8,0x7fuf8)
+@test Colorant"rgb(55,217,127)" === RGB{U8}(0x37uf8,0xd9uf8,0x7fuf8)
 @test parse(Colorant, "rgba(55,217,127,0.5)") === RGBA{U8}(0x37uf8,0xd9uf8,0x7fuf8,0.5)
 @test parse(Colorant, "rgb(55,217,127)") === RGB{U8}(0x37uf8,0xd9uf8,0x7fuf8)
 @test parse(Colorant, "rgba(55,217,127,0.5)") === RGBA{U8}(0x37uf8,0xd9uf8,0x7fuf8,0.5)
 @test parse(Colorant, "hsl(120, 100%, 50%)") === HSL{Float32}(120,1.0,.5)
+@test Colorant"hsl(120, 100%, 50%)" === HSL{Float32}(120,1.0,.5)
 @test parse(RGB{U8}, "hsl(120, 100%, 50%)") === convert(RGB{U8}, HSL{Float32}(120,1.0,.5))
 @test_throws ErrorException  parse(Colorant, "hsl(120, 100, 50)")
 @test parse(Colorant, "#D0FF58") === RGB(0xD0uf8,0xFFuf8,0x58uf8)

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -4,19 +4,19 @@ import ColorTypes: eltype_default
 
 # Color parsing
 const redU8 = parse(Colorant, "red")
-@test Colorant"red" == redU8
+@test colorant"red" == redU8
 @test isa(redU8, RGB{U8})
 @test redU8 == RGB(1,0,0)
 const redF64 = convert(RGB{Float64}, redU8)
 @test parse(RGB{Float64}, "red") === RGB{Float64}(1,0,0)
 @test isa(parse(HSV, "blue"), HSV)
 @test parse(Colorant, "rgb(55,217,127)") === RGB{U8}(0x37uf8,0xd9uf8,0x7fuf8)
-@test Colorant"rgb(55,217,127)" === RGB{U8}(0x37uf8,0xd9uf8,0x7fuf8)
+@test colorant"rgb(55,217,127)" === RGB{U8}(0x37uf8,0xd9uf8,0x7fuf8)
 @test parse(Colorant, "rgba(55,217,127,0.5)") === RGBA{U8}(0x37uf8,0xd9uf8,0x7fuf8,0.5)
 @test parse(Colorant, "rgb(55,217,127)") === RGB{U8}(0x37uf8,0xd9uf8,0x7fuf8)
 @test parse(Colorant, "rgba(55,217,127,0.5)") === RGBA{U8}(0x37uf8,0xd9uf8,0x7fuf8,0.5)
 @test parse(Colorant, "hsl(120, 100%, 50%)") === HSL{Float32}(120,1.0,.5)
-@test Colorant"hsl(120, 100%, 50%)" === HSL{Float32}(120,1.0,.5)
+@test colorant"hsl(120, 100%, 50%)" === HSL{Float32}(120,1.0,.5)
 @test parse(RGB{U8}, "hsl(120, 100%, 50%)") === convert(RGB{U8}, HSL{Float32}(120,1.0,.5))
 @test_throws ErrorException  parse(Colorant, "hsl(120, 100, 50)")
 @test parse(Colorant, "#D0FF58") === RGB(0xD0uf8,0xFFuf8,0x58uf8)

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -3,20 +3,20 @@ using Base.Test
 import ColorTypes: eltype_default
 
 # Color parsing
-const redU8 = parse(Color, "red")
+const redU8 = parse(Colorant, "red")
 @test isa(redU8, RGB{U8})
 @test redU8 == RGB(1,0,0)
 const redF64 = convert(RGB{Float64}, redU8)
 @test parse(RGB{Float64}, "red") === RGB{Float64}(1,0,0)
 @test isa(parse(HSV, "blue"), HSV)
-@test parse(Color, "rgb(55,217,127)") === RGB{U8}(0x37uf8,0xd9uf8,0x7fuf8)
-@test parse(Color, "rgba(55,217,127,0.5)") === RGBA{U8}(0x37uf8,0xd9uf8,0x7fuf8,0.5)
-@test parse(Color, "rgb(55,217,127)") === RGB{U8}(0x37uf8,0xd9uf8,0x7fuf8)
-@test parse(Color, "rgba(55,217,127,0.5)") === RGBA{U8}(0x37uf8,0xd9uf8,0x7fuf8,0.5)
-@test parse(Color, "hsl(120, 100%, 50%)") === HSL{Float32}(120,1.0,.5)
+@test parse(Colorant, "rgb(55,217,127)") === RGB{U8}(0x37uf8,0xd9uf8,0x7fuf8)
+@test parse(Colorant, "rgba(55,217,127,0.5)") === RGBA{U8}(0x37uf8,0xd9uf8,0x7fuf8,0.5)
+@test parse(Colorant, "rgb(55,217,127)") === RGB{U8}(0x37uf8,0xd9uf8,0x7fuf8)
+@test parse(Colorant, "rgba(55,217,127,0.5)") === RGBA{U8}(0x37uf8,0xd9uf8,0x7fuf8,0.5)
+@test parse(Colorant, "hsl(120, 100%, 50%)") === HSL{Float32}(120,1.0,.5)
 @test parse(RGB{U8}, "hsl(120, 100%, 50%)") === convert(RGB{U8}, HSL{Float32}(120,1.0,.5))
-@test_throws ErrorException  parse(Color, "hsl(120, 100, 50)")
-@test parse(Color, "#D0FF58") === RGB(0xD0uf8,0xFFuf8,0x58uf8)
+@test_throws ErrorException  parse(Colorant, "hsl(120, 100, 50)")
+@test parse(Colorant, "#D0FF58") === RGB(0xD0uf8,0xFFuf8,0x58uf8)
 
 @test hex(RGB(1,0.5,0)) == "FF8000"
 @test hex(RGBA(1,0.5,0,0.25)) == "40FF8000"
@@ -128,7 +128,7 @@ end
 
 # Test vector space operations
 import Base.full
-full(T::OpaqueColor) = map(x->getfield(T, x), fieldnames(T)) #Allow test to access numeric elements
+full(T::Color) = map(x->getfield(T, x), fieldnames(T)) #Allow test to access numeric elements
 # Generated from:
 #=
 julia> for t in subtypes(ColorValue)


### PR DESCRIPTION
Probably the only thing to discuss is whether the literal string macro should be called `Colorant"red"` or `colorant"red"`. Since it also works for strings like `"rgba(1,0,0,0.5)"`, I'm just going to preemptively say that anyone who wishes it could be called `"Color"` or `"color"` is going to have to be extremely persuasive.