### PR TITLE
Support arithmetic only for linear color spaces

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1,16 +1,11 @@
 # Arithmetic
-#XYZ is a linear vector space
-+{T<:Number}(a::XYZ{T}, b::XYZ{T}) = XYZ(a.x+b.x, a.y+b.y, a.z+b.z)
--{T<:Number}(a::XYZ{T}, b::XYZ{T}) = XYZ(a.x-b.x, a.y-b.y, a.z-b.z)
--(a::XYZ) = XYZ(-a.x, -a.y, -a.z)
-*(c::Number, a::XYZ) = XYZ(c*a.x, c*a.y, c*a.z)
-
-#Most color spaces are nonlinear, so do the arithmetic in XYZ and convert back
-+{T<:Color}(a::T, b::T) = convert(T, convert(XYZ, a) + convert(XYZ, b))
-*{T<:Color}(c::Number, a::T) = convert(T, c * convert(XYZ, a))
-*{T<:Color}(c::Number, a::T) = convert(T, c * convert(XYZ, a))
-
-/(a::Color, c::Number) = *(1/c, a)
+#XYZ and LMS are linear vector spaces
+typealias Linear3 Union(XYZ, LMS)
++{C<:Linear3}(a::C, b::C) = C(comp1(a)+comp1(b), comp2(a)+comp2(b), comp3(a)+comp3(b))
+-{C<:Linear3}(a::C, b::C) = C(comp1(a)-comp1(b), comp2(a)-comp2(b), comp3(a)-comp3(b))
+-(a::Linear3) = typeof(a)(-comp1(a), -comp2(a), -comp3(a))
+*(c::Number, a::Linear3) = base_color_type(a)(c*comp1(a), c*comp2(a), c*comp3(a))
+/(a::Linear3, c::Number) = base_color_type(a)(comp1(a)/c, comp2(a)/c, comp3(a)/c)
 
 # Algorithms relating to color processing and generation
 

--- a/src/colormaps.jl
+++ b/src/colormaps.jl
@@ -128,6 +128,9 @@ function sequential_palette(h,
         M=mod(180.0+h1-h0, 360)-180.0
         mod(h0+a*M, 360)
     end
+    function mix_linearly{C<:Color}(a::C, b::C, s)
+        base_color_type(C)((1-s)*comp1(a)+s*comp1(b), (1-s)*comp2(a)+s*comp2(b), (1-s)*comp3(a)+s*comp3(b))
+    end
 
     pstart=convert(LCHuv, wcolor)
     p1=MSC(h)
@@ -146,9 +149,9 @@ function sequential_palette(h,
     p0c=min(MSC(p0h,p0l), d*s*pend.c)
     p0=LCHuv(p0l,p0c,p0h)
 
-    q0=(1.0-s)*p0+s*p1
-    q2=(1.0-s)*p2+s*p1
-    q1=0.5*(q0+q2)
+    q0=mix_linearly(p0,p1,s)
+    q2=mix_linearly(p2,p1,s)
+    q1=mix_linearly(q0,q2,0.5)
 
     pal = RGB{Float64}[]
 

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -144,38 +144,12 @@ julia> for t in subtypes(ColorValue)
           end
        end
 =#
-@test_approx_eq_eps DIN99o{Float64}(0.125,0.5,0.0)+DIN99o{Float64}(0.2,0.7,0.4) DIN99o{Float64}(0.3249177178200238,1.1851041291240045,0.39613501908850973) 91eps()
-@test_approx_eq_eps 3DIN99o{Float64}(0.125,0.5,0.03) DIN99o{Float64}(0.3748457441768566,1.4684725814274917,0.08810835488564604) 91eps()
-
-@test_approx_eq_eps DIN99{Float64}(0.125,0.5,0.0)+DIN99{Float64}(0.2,0.7,0.4) DIN99{Float64}(0.3247634199662825,1.1845967897238356,0.3960040943105819) 91eps()
-@test_approx_eq_eps 3DIN99{Float64}(0.125,0.5,0.03) DIN99{Float64}(0.37455660462520735,1.467408770792347,0.08804452624754316) 91eps()
-
-@test_approx_eq_eps HSL{Float64}(0.125,0.5,0.0)+HSL{Float64}(0.2,0.7,0.4) HSL{Float64}(0.20003618248898006,0.7000000631323785,0.39999995233870655) 91eps()
-@test_approx_eq_eps 3HSL{Float64}(0.125,0.5,0.03) HSL{Float64}(0.17819347263565585,0.3941314428230695,0.07391855489379041) 91eps()
-
-@test_approx_eq_eps HSV{Float64}(0.125,0.5,0.0)+HSV{Float64}(0.2,0.7,0.4) HSV{Float64}(0.20002334068804029,0.7000000071033119,0.3999999666630183) 91eps()
-@test_approx_eq_eps 3HSV{Float64}(0.125,0.5,0.03) HSV{Float64}(0.15547682101166416,0.42727995497106286,0.07819689447804021) 91eps()
-
-@test_approx_eq_eps LCHab{Float64}(0.125,0.5,0.0)+LCHab{Float64}(0.2,0.7,0.4) LCHab{Float64}(0.3249999999999993,1.1999928922680212,0.23333346495867205) 91eps()
-@test_approx_eq_eps 3LCHab{Float64}(0.125,0.5,0.03) LCHab{Float64}(0.375,1.4999999999999816,0.03000000000047518) 91eps()
-
-@test_approx_eq_eps LCHuv{Float64}(0.125,0.5,0.0)+LCHuv{Float64}(0.2,0.7,0.4) LCHuv{Float64}(0.32500000000000007,1.200147006104681,0.2329439337672688) 91eps()
-@test_approx_eq_eps 3LCHuv{Float64}(0.125,0.5,0.03) LCHuv{Float64}(0.375,1.5000000000000007,0.03000000000000911) 91eps()
 
 @test_approx_eq_eps LMS{Float64}(0.125,0.5,0.0)+LMS{Float64}(0.2,0.7,0.4) LMS{Float64}(0.32500000000000007,1.2000000000000002,0.4000000000000001) 91eps()
 @test_approx_eq_eps 3LMS{Float64}(0.125,0.5,0.03) LMS{Float64}(0.37499999999999994,1.4999999999999998,0.09000000000000001) 91eps()
 
-@test_approx_eq_eps Lab{Float64}(0.125,0.5,0.0)+Lab{Float64}(0.2,0.7,0.4) Lab{Float64}(0.3249999999999993,1.2000000000000066,0.40000000000000036) 91eps()
-@test_approx_eq_eps 3Lab{Float64}(0.125,0.5,0.03) Lab{Float64}(0.375,1.4999999999999876,0.09000000000001229) 91eps()
-
-@test_approx_eq_eps Luv{Float64}(0.125,0.5,0.0)+Luv{Float64}(0.2,0.7,0.4) Luv{Float64}(0.32500000000000007,1.2112171964760525,0.3551312140957904) 91eps()
-@test_approx_eq_eps 3Luv{Float64}(0.125,0.5,0.03) Luv{Float64}(0.375,1.4999999999999998,0.09000000000000033) 91eps()
-
 @test_approx_eq_eps XYZ{Float64}(0.125,0.5,0.0)+XYZ{Float64}(0.2,0.7,0.4) XYZ{Float64}(0.325,1.2,0.4) 91eps()
 @test_approx_eq_eps 3XYZ{Float64}(0.125,0.5,0.03) XYZ{Float64}(0.375,1.5,0.09) 91eps()
-
-@test_approx_eq_eps xyY{Float64}(0.125,0.5,0.0)+xyY{Float64}(0.2,0.7,0.4) xyY{Float64}(0.2,0.7,0.4) 91eps()
-@test_approx_eq_eps 3xyY{Float64}(0.125,0.5,0.03) xyY{Float64}(0.125,0.5,0.09) 91eps()
 
 #59
 @test Colors.xyz_to_uv(XYZ{Float64}(0.0, 0.0, 0.0)) === (0.0, 0.0)
@@ -183,8 +157,6 @@ julia> for t in subtypes(ColorValue)
 @test Colors.xyz_to_uv(XYZ{Float64}(0.0, 1.0, 1.0)) === (0.0, 0.5)
 @test Colors.xyz_to_uv(XYZ{Float64}(1.0, 0.0, 1.0)) === (1.0, 0.0)
 @test Colors.xyz_to_uv(XYZ{Float64}(1.0, 0.0, 0.0)) === (4.0, 0.0)
-
-@test 1.0LCHuv(0.0, 0.0, 0.0) === LCHuv(0.0, 0.0, 0.0)
 
 # YIQ
 @test convert(YIQ, RGB(1,0,0)) == YIQ{Float32}(0.299, 0.595716, 0.211456)


### PR DESCRIPTION
As @jiahao has pointed out, arithmetic is complicated with Colors; in particular, nonlinear colorspaces should not be treated in a cavalier fashion. In Color.jl, we've had support for arithmetic through a more careful procedure: `a+b -> original_colorspace(XYZ(a) + XYZ(b))`, exploiting the fact that `XYZ` is, in fact, a vector space.

The problem with this seemingly-rational approach is that it fails due to gamut-correction. This was discovered while adding a "sanity-check" for the diagonal in the diagram that appears in https://github.com/JuliaGraphics/ColorVectorSpace.jl (@jiahao, I think you'll like that diagram). For example, one identity that should be satisfied in *any* colorspace is `mean(a,a) == a`, where `mean(a,b)` averages `a` and `b`. Let's see how we fare with Color.jl:
```jl
julia> using Color

julia> a = RGB(0.2,0,0)
Color.RGB{Float64}(0.2,0.0,0.0)

julia> 0.5*(a+a)
Color.RGB{Float64}(0.19999996068022607,1.1275668676820975e-7,0.0)   # works!

julia> a = RGB(0.8,0,0)
Color.RGB{Float64}(0.8,0.0,0.0)

julia> 0.5*(a+a)
Color.RGB{Float64}(0.735356922117825,1.8798490079085205e-6,0.0)    # oh, drat!

# compare:
julia> axyz = convert(XYZ, a)
Color.XYZ{Float64}(0.24905245040585275,0.12841771125364737,0.011674337386695216)

julia> convert(RGB, 0.5*(axyz+axyz))
Color.RGB{Float64}(0.799999934081552,1.0283349222330366e-6,0.0)    # works!
```
I think the only reasonable option is to disable arithmetic for any color type except those in a linear color space, and force users to do the conversion manually. OK with you, @jiahao?

I'm also CCing @glenn-sweeney or any other colorimetry experts, to ask whether my modification of `sequential_palette` is as intended. Or should we convert to `XYZ` before performing those operations?