### PR TITLE
Add a fallback for `parse(Colorant, ::Colorant)`

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -135,6 +135,8 @@ end
 
 Base.parse{C<:Colorant}(::Type{C}, desc) = convert(C, parse(Colorant, desc))::C
 
+Base.parse{C<:Colorant}(::Type{C}, c::Colorant) = convert(C, c)::C
+
 macro colorant_str(ex)
     isa(ex, AbstractString) || error("colorant requires literal strings")
     col = parse(Colorant, ex)


### PR DESCRIPTION
I have some reservations about this because of the following behavior:
```jl
julia> parse(Int, "5")
5

julia> parse(Int, 5)
ERROR: MethodError: `parse` has no method matching parse(::Type{Int64}, ::Int64)
Closest candidates are:
  parse{T<:Integer}(::Type{T<:Integer}, ::Char)
  parse{T<:Integer}(::Type{T<:Integer}, ::Char, ::Integer)
  parse{T<:Integer}(::Type{T<:Integer}, ::AbstractString, ::Integer)
```
But this is one way to fix https://github.com/dcjones/Gadfly.jl/issues/756. I've got another PR I'm preparing for Gadfly that is an alternative fix. Thoughts?