### PR TITLE
distinguishable_colors: restrict candidates to RGB-realizable colors

### DIFF
--- a/src/colormaps.jl
+++ b/src/colormaps.jl
@@ -45,9 +45,8 @@ function distinguishable_colors{T<:Color}(n::Integer,
     candidate = Array(Lab{Float64}, N)
     j = 0
     for h in hchoices, c in cchoices, l in lchoices
-        candidate[j+=1] = LCHab(l, c, h)
-        # rgb = convert(RGB, LCHab(l, c, h))
-        # candidate[j+=1] = convert(LCHab, rgb)
+        rgb = convert(RGB, LCHab(l, c, h))
+        candidate[j+=1] = convert(LCHab, rgb)
     end
 
     # Transformed colors


### PR DESCRIPTION
I can't remember where this originally came up, but I believe that @m-lohmann or @tbreloff discovered that distinguishability improves if you ensure that all candidate colors are within the gamut of RGB.
