### PR TITLE
Fix RGB->HSL conversion InexactError. Fixes ColorTypes #40

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -210,8 +210,9 @@ cnvt{T}(::Type{HSV{T}}, c::Color3) = cnvt(HSV{T}, convert(RGB{T}, c))
 # -----------------
 
 function cnvt{T}(::Type{HSL{T}}, c::AbstractRGB)
-    c_min = min(red(c), green(c), blue(c))
-    c_max = max(red(c), green(c), blue(c))
+    r, g, b = T(red(c)), T(green(c)), T(blue(c))
+    c_min = min(r, g, b)
+    c_max = max(r, g, b)
     l = (c_max + c_min) / 2
 
     if c_max == c_min
@@ -223,11 +224,11 @@ function cnvt{T}(::Type{HSL{T}}, c::AbstractRGB)
     end
 
     if c_max == red(c)
-        h = (green(c) - blue(c)) / (c_max - c_min)
+        h = (g - b) / (c_max - c_min)
     elseif c_max == green(c)
-        h = convert(T, 2) + (blue(c) - red(c)) / (c_max - c_min)
+        h = convert(T, 2) + (b - r) / (c_max - c_min)
     else
-        h = convert(T, 4) + (red(c) - green(c)) / (c_max - c_min)
+        h = convert(T, 4) + (r - g) / (c_max - c_min)
     end
 
     h *= 60

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -172,6 +172,9 @@ julia> for t in subtypes(ColorValue)
 @test Colors.xyz_to_uv(XYZ{Float64}(1.0, 0.0, 1.0)) === (1.0, 0.0)
 @test Colors.xyz_to_uv(XYZ{Float64}(1.0, 0.0, 0.0)) === (4.0, 0.0)
 
+# ColorTypes.jl issue #40
+@test_approx_eq_eps convert(HSL, RGB{U8}(0.678, 0.847, 0.902)) HSL{Float32}(194.73685f0,0.5327105f0,0.7901961f0) 100eps(Float32)
+
 # YIQ
 @test convert(YIQ, RGB(1,0,0)) == YIQ{Float32}(0.299, 0.595716, 0.211456)
 @test convert(YIQ, RGB(0,1,0)) == YIQ{Float32}(0.587, -0.274453, -0.522591)


### PR DESCRIPTION
CC @gabrielgellner. All I did was make sure I convert to the output eltype (e.g., `Float32`) before performing any arithmetic operations.