### PR TITLE
Fix depwarn on 0.6 due to vectorized functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
     - osx
     - linux
 julia:
-    - release
+    - 0.4
+    - 0.5
     - nightly
 notifications:
     email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 0.4
 ColorTypes 0.2
 FixedPointNumbers 0.1
 Reexport
-Compat 0.8.0
+Compat 0.9.1

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -149,9 +149,9 @@ protanopic(c::Color)   = protanopic(c, 1.0)
 deuteranopic(c::Color) = deuteranopic(c, 1.0)
 tritanopic(c::Color)   = tritanopic(c, 1.0)
 
-@vectorize_1arg Color protanopic
-@vectorize_1arg Color deuteranopic
-@vectorize_1arg Color tritanopic
+Compat.@dep_vectorize_1arg Color protanopic
+Compat.@dep_vectorize_1arg Color deuteranopic
+Compat.@dep_vectorize_1arg Color tritanopic
 
 # MSC - Most Saturated Colorant for given hue h
 # ---------------------

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -199,7 +199,7 @@ r4 = RGB4(1,0,0)
 @test convert(BGR{Float32}, r4) == BGR{Float32}(1,0,0)
 
 # Test accuracy of conversion
-csconv = jldopen("test_conversions.jld") do file
+csconv = jldopen(joinpath(dirname(@__FILE__), "test_conversions.jld")) do file
     read(file, "csconv")
 end
 


### PR DESCRIPTION
Requires JuliaLang/Compat.jl#280 and a new `Compat` tag.
