### PR TITLE
Use nonnegative definite expression in arg for sqrt

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -255,7 +255,7 @@ function cnvt{T}(::Type{HSI{T}}, c::AbstractRGB)
     i = isum/3
     m = min(r, g, b)
     s = i > 0 ? 1-m/i : 1-one(i)/one(i) # the latter is a type-stable 0
-    val = (r-(g+b)/2)/sqrt(r^2+g^2+b^2-r*g-r*b-g*b)
+    val = (r-(g+b)/2)/sqrt(((r-g)^2 + (r-b)^2 + (g-b)^2)/2)
     val = clamp(val, -one(val), one(val))
     h = acosd(val)
     if b > g

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -232,3 +232,8 @@ end
 
 # https://github.com/timholy/Images.jl/pull/445#issuecomment-189866806
 @test convert(Gray, RGB{U8}(0.145,0.145,0.145)) == Gray{U8}(0.145)
+
+# Issue #257
+c = RGB{Float16}(0.9473,0.962,0.9766)
+hsi = convert(HSI, c)
+@test hsi.i > 0.96 && hsi.h ≈ 210


### PR DESCRIPTION
In the expression for conversion from RGB->HSI, the argument to the square root is written as
```jl
r^2+g^2+b^2-r*g-r*b-g*b
```
but an analytically-identical expression is
```jl
((r-g)^2 + (r-b)^2 + (g-b)^2)/2
```
This latter version has the distinct advantage that it's guaranteed to be nonnegative even in the face of roundoff error. Fixes #257.