### PR TITLE
Switch to explicit reinterpret for UInt32 <---> RGB24 & friends

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
-ColorTypes 0.2.7
+ColorTypes 0.2.9
 FixedPointNumbers 0.1.8
 Reexport
 Compat 0.9.1

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -771,12 +771,14 @@ cnvt{T}(::Type{YCbCr{T}}, c::Color3) = cnvt(YCbCr{T}, convert(RGB{T}, c))
 
 convert(::Type{RGB24}, c::RGB24) = c
 convert(::Type{RGB24}, c::AbstractRGB{UFixed8}) = RGB24(red(c), green(c), blue(c))
-convert(::Type{RGB24}, c::AbstractRGB) = RGB24((reinterpret(U8(red(c))) % UInt32)<<16 +
-                                               (reinterpret(U8(green(c))) % UInt32)<<8 +
-                                                reinterpret(U8(blue(c))) % UInt32)
+function convert(::Type{RGB24}, c::AbstractRGB)
+    u = (reinterpret(U8(red(c))) % UInt32)<<16 +
+        (reinterpret(U8(green(c))) % UInt32)<<8 +
+        reinterpret(U8(blue(c))) % UInt32
+    reinterpret(RGB24, u)
+end
 
 convert(::Type{RGB24}, c::Color) = convert(RGB24, convert(RGB{UFixed8}, c))
-
 
 # To ARGB32
 # ----------------
@@ -784,10 +786,18 @@ convert(::Type{RGB24}, c::Color) = convert(RGB24, convert(RGB{UFixed8}, c))
 convert(::Type{ARGB32}, c::ARGB32) = c
 convert{CV<:AbstractRGB{UFixed8}}(::Type{ARGB32}, c::TransparentColor{CV}) =
     ARGB32(red(c), green(c), blue(c), alpha(c))
-convert(::Type{ARGB32}, c::TransparentColor) =
-    ARGB32(convert(RGB24, c).color | (reinterpret(U8(alpha(c)))%UInt32)<<24)
-convert(::Type{ARGB32}, c::Color) = ARGB32(convert(RGB24, c).color | 0xff000000)
-convert(::Type{ARGB32}, c::Color, alpha) = ARGB32(convert(RGB24, c).color | (reinterpret(U8(alpha))%UInt32)<<24)
+function convert(::Type{ARGB32}, c::TransparentColor)
+    u = reinterpret(UInt32, convert(RGB24, c)) | (reinterpret(U8(alpha(c)))%UInt32)<<24
+    reinterpret(ARGB32, u)
+end
+function convert(::Type{ARGB32}, c::Color)
+    u = reinterpret(UInt32, convert(RGB24, c)) | 0xff000000
+    reinterpret(ARGB32, u)
+end
+function convert(::Type{ARGB32}, c::Color, alpha)
+    u = reinterpret(UInt32, convert(RGB24, c)) | (reinterpret(U8(alpha))%UInt32)<<24
+    reinterpret(ARGB32, u)
+end
 
 # To Gray
 # -------

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -29,8 +29,8 @@ const redF64 = convert(RGB{Float64}, redU8)
 
 fractional_types = (RGB, BGR, RGB1, RGB4)  # types that support Fractional
 
-const red24 = RGB24(0x00ff0000)
-const red32 = ARGB32(0xffff0000)
+const red24 = reinterpret(RGB24, 0x00ff0000)
+const red32 = reinterpret(ARGB32, 0xffff0000)
 for T in (Float64, Float32, UFixed8)
     c = RGB(one(T), zero(T), zero(T))
     @test eltype(c) == T
@@ -113,12 +113,18 @@ ac = RGBA(redF64)
 @test convert(HSVA{Float32}, ac) == HSVA{Float32}(convert(HSV{Float32}, redF64), 1.0f0)
 @test convert(RGBA, redF64) == ac
 
-@test convert(ARGB32, ac) == ARGB32(0xffff0000)
-@test convert(UInt32, convert(ARGB32, ac)) == 0xffff0000
-@test convert(RGB24, RGB(0xffuf8,0x00uf8,0x00uf8)) == RGB24(0x00ff0000)
-@test convert(UInt32, convert(RGB24, RGB(0xffuf8,0x00uf8,0x00uf8))) == 0x00ff0000
+@test convert(ARGB32, ac) == reinterpret(ARGB32, 0xffff0000)
+@test convert(ARGB32, RGB(1,0,0)) == reinterpret(ARGB32, 0xffff0000)
+ac32 = convert(ARGB32, RGB(1,0,0), 0.5)
+@test ac32 == reinterpret(ARGB32, 0x80ff0000)
+@test convert(ARGB32, ac32) === ac32
+@test convert(ARGB32, BGRA(1,0,0,0.5)) == reinterpret(ARGB32, 0x80ff0000)
+@test reinterpret(UInt32, convert(ARGB32, ac)) == 0xffff0000
+@test convert(RGB24, RGB(0xffuf8,0x00uf8,0x00uf8)) == reinterpret(RGB24, 0x00ff0000)
+@test reinterpret(UInt32, convert(RGB24, RGB(0xffuf8,0x00uf8,0x00uf8))) == 0x00ff0000
 redhsv = convert(HSV, redF64)
-@test convert(RGB24, redhsv) == RGB24(0x00ff0000)
+@test convert(RGB24, red24) === red24
+@test convert(RGB24, redhsv) == reinterpret(RGB24, 0x00ff0000)
 @test_throws ArgumentError convert(RGB24,  RGB(0, 1.1, 0))
 @test_throws ArgumentError convert(ARGB32, RGBA(0, 1.1, 0, 0.8))
 @test_throws ArgumentError convert(ARGB32, RGBA(0, 0.8, 0, 1.1))


### PR DESCRIPTION
Fixes deprecation warnings from ColorTypes