### PR TITLE
Fixed missing "=" in xml tag in Base.show

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -4,7 +4,7 @@
 @compat function Base.show(io::IO, ::MIME"image/svg+xml", c::Color)
     write(io,
         """
-        <?xml version"1.0" encoding="UTF-8"?>
+        <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
          "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
         <svg xmlns="http://www.w3.org/2000/svg" version="1.1"


### PR DESCRIPTION
Dear all,
the malformed XML tag may trigger a warning when converting the generated SVG with e.g inkscape. Conversion is successful though. Very minor issue in a rather obscure use case :)

Best,
Stephan