### PR TITLE
Add promotions between Gray and multi-component Colorants

### DIFF
--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -34,19 +34,4 @@ include("colormaps.jl")
 include("display.jl")
 include("colormatch.jl")
 
-@deprecate rgba RGBA
-@deprecate hsva HSVA
-@deprecate hsla HSLA
-@deprecate xyza XYZA
-@deprecate xyYa xyYA
-@deprecate laba LabA
-@deprecate luva LuvA
-@deprecate lchaba LCHabA
-@deprecate lchuva LCHuvA
-@deprecate din99a DIN99A
-@deprecate din99da DIN99dA
-@deprecate din99oa DIN99oA
-@deprecate lmsa LMSA
-@deprecate argb32 ARGB32
-
 end # module

--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -8,7 +8,11 @@ using FixedPointNumbers, ColorTypes, Reexport, Compat
 export U8, U16
 
 typealias AbstractGray{T} Color{T,1}
+using ColorTypes: TransparentGray
+typealias AbstractAGray{C<:AbstractGray,T} AlphaColor{C,T,2}
+typealias AbstractGrayA{C<:AbstractGray,T} ColorAlpha{C,T,2}
 typealias Color3{T} Color{T,3}
+typealias Transparent4{C<:Color3,T} TransparentColor{C,T,4}
 
 import Base: ==, +, -, *, /
 import Base: convert, eltype, hex, isless, linspace, show, typemin, typemax
@@ -27,6 +31,7 @@ include("utilities.jl")
 
 # Include other module components
 include("conversions.jl")
+include("promotions.jl")
 include("algorithms.jl")
 include("parse.jl")
 include("differences.jl")

--- a/src/promotions.jl
+++ b/src/promotions.jl
@@ -1,0 +1,6 @@
+Base.promote_rule{C3<:Color3,Cgray<:AbstractGray}(::Type{C3}, ::Type{Cgray}) = base_colorant_type(C3){promote_type(eltype(C3), eltype(Cgray))}
+Base.promote_rule{C3<:Color3,Cagray<:AbstractAGray}(::Type{C3}, ::Type{Cagray}) = alphacolor(base_colorant_type(C3)){promote_type(eltype(C3), eltype(Cagray))}
+Base.promote_rule{C3<:Color3,Cgraya<:AbstractGrayA}(::Type{C3}, ::Type{Cgraya}) = coloralpha(base_colorant_type(C3)){promote_type(eltype(C3), eltype(Cgraya))}
+
+Base.promote_rule{C4<:Transparent4,Cgray<:AbstractGray}(::Type{C4}, ::Type{Cgray}) = base_colorant_type(C4){promote_type(eltype(C4), eltype(Cgray))}
+Base.promote_rule{C4<:Transparent4,Cgray<:TransparentGray}(::Type{C4}, ::Type{Cgray}) = base_colorant_type(C4){promote_type(eltype(C4), eltype(Cgray))}

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -4,6 +4,18 @@ using ColorTypes: eltype_default
 
 r8(x) = reinterpret(N0f8, x)
 
+# Promotions
+a, b = promote(RGB(1,0,0), Gray(0.8))
+@test isa(a, RGB{Float64}) && isa(b, RGB{Float64})
+a, b = promote(RGBA(1,0,0), Gray(0.8))
+@test isa(a, RGBA{Float64}) && isa(b, RGBA{Float64})
+a, b = promote(RGBA(1,0,0), GrayA(0.8))
+@test isa(a, RGBA{Float64}) && isa(b, RGBA{Float64})
+a, b = promote(RGB(1,0,0), GrayA(0.8))
+@test isa(a, RGBA{Float64}) && isa(b, RGBA{Float64})
+a, b = promote(RGB(1,0,0), AGray(0.8))
+@test isa(a, ARGB{Float64}) && isa(b, ARGB{Float64})
+
 # Color parsing
 const redN0f8 = parse(Colorant, "red")
 @test colorant"red" == redN0f8


### PR DESCRIPTION
Amazing that we haven't noticed the lack of these previously. These rules aren't perfect, but I'll file an issue detailing what needs to improve.

@tkelman, I also noticed some stale (>1 year old) `@deprecate` statements, which I deleted. Does deleting those mean we need to do a minor version bump?
