### PR TITLE
Fix parsing of 3-digit RGB (#rgb) (#280)

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -58,9 +58,9 @@ function _parse_colorant(desc::AbstractString)
 
     mat = match(col_pat_hex1, desc_)
     if mat != nothing
-        return RGB{N0f8}((16 * parse(Int, mat.captures[2], 16)) / 255,
-                       (16 * parse(Int, mat.captures[3], 16)) / 255,
-                       (16 * parse(Int, mat.captures[4], 16)) / 255)
+        return RGB{N0f8}(parse(Int, mat.captures[2], 16) / 15,
+                       parse(Int, mat.captures[3], 16) / 15,
+                       parse(Int, mat.captures[4], 16) / 15)
     end
 
     mat = match(col_pat_rgb, desc_)

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -34,6 +34,7 @@ const redF64 = convert(RGB{Float64}, redN0f8)
 @test parse(RGB{N0f8}, "hsl(120, 100%, 50%)") === convert(RGB{N0f8}, HSL{Float32}(120,1.0,.5))
 @test_throws ErrorException  parse(Colorant, "hsl(120, 100, 50)")
 @test parse(Colorant, "#D0FF58") === RGB(r8(0xD0),r8(0xFF),r8(0x58))
+@test parse(Colorant, "#FB0") === RGB(r8(0xFF),r8(0xBB),r8(0x00))
 
 @test parse(Colorant, :red) === colorant"red"
 @test parse(Colorant, colorant"red") === colorant"red"


### PR DESCRIPTION
fix parsing of "#rgb" to conform to the CSS specification