### PR TITLE
more faithful preservation of aspect ratio when displaying as SVG

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -1,6 +1,10 @@
 # Displaying color swatches
 # -------------------------
 
+const max_width = 180
+const max_height = 150
+const max_pixel_size = 25
+
 function Base.show(io::IO, ::MIME"image/svg+xml", c::Color)
     write(io,
         """
@@ -15,12 +19,26 @@ function Base.show(io::IO, ::MIME"image/svg+xml", c::Color)
         """)
 end
 
-function Base.show{T <: Color}(io::IO, ::MIME"image/svg+xml",
-                                       cs::AbstractVecOrMat{T})
-    m,n = ndims(cs) == 2 ? size(cs) : (1,length(cs))
+function Base.show{T <: Color}(io::IO, ::MIME"image/svg+xml", 
+                               cs::AbstractVector{T})
+    show(io, MIME"image/svg+xml"(), reshape(cs, (1, length(cs))))
+end
 
-    xsize,xpad = n > 50 ? (250/n,0) : n > 18 ? (5.,1) : n > 12 ? (10.,1) : n > 1 ? (15.,1) : (25.,0)
-    ysize,ypad = m > 28 ? (150/m,0) : m > 14 ? (5.,1) : m > 9 ? (10.,1) : m > 1 ? (15.,1) : (25.,0)
+function Base.show{T <: Color}(io::IO, ::MIME"image/svg+xml",
+                                       cs::AbstractMatrix{T})
+    m, n = size(cs)
+    apsect_ratio = clamp(n / m,
+                         max_pixel_size / max_height,
+                         max_width / max_pixel_size)
+    pixel_aspect = apsect_ratio / (n / m)
+    scale_factor = min(max_width / (n * max_pixel_size * pixel_aspect),
+                       max_height / (m * max_pixel_size),
+                       1)
+    ysize = max_pixel_size * scale_factor
+    xsize = ysize * pixel_aspect
+
+    xpad = n > 50 ? 0 : 1
+    ypad = m > 28 ? 0 : 1
 
     write(io,
         """


### PR DESCRIPTION
Fixes #283 

This rewrites the logic to choose the rectangle size for each color when rendering to SVG. The result should be that: 

* a much wider range of aspect ratios are faithfully preserved (the specific range is 0.16 to 7.2, which is a consequence of the particular max width, max height, and max pixel size chosen)
* aspect ratios outside that range are clamped to the nearest aspect ratio in the range
* color matrices with `m` > `n` are always drawn taller than they are wide, and vice versa
* a color matrix with `m + 1` rows is never shorter than a color matrix with `m` rows, and a color matrix with `n + 1` columns is never thinner than a color matrix with `n` columns

Here's the particular motivating example from #283 after this change:

![screen shot 2017-04-06 at 3 11 07 pm](https://cloud.githubusercontent.com/assets/591886/24771352/56556d3a-1adb-11e7-9e92-089bd1c6cf80.png)

I also made another minor change: previously, there was one `show()` method for vectors and matrices, which required checking ndim() in a couple of places. I replaced that with `show(v::Vector) = show(reshape(v, (1, length(v))))` since `reshape()` doesn't copy in Julia >= v0.5. 

I would suggest playing around with this for a variety of sizes to see how it behaves. I found the following snippet useful in my testing (inside IJulia):

```julia
using Colors, Interact
c = distinguishable_colors(40 * 60)

@manipulate for m in 1:40, n in 1:60
    reshape(@view(c[1:(m * n)]), m, n)
end
```