### PR TITLE
fix more deprecations on 0.7-rc2

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.7-alpha
+julia 0.7-rc2
 ColorTypes 0.7.0
 FixedPointNumbers 0.5.0
 Reexport

--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module Colors
 
 using FixedPointNumbers, ColorTypes, Reexport, Printf

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -167,8 +167,8 @@ cnvt(::Type{CV}, c::LCHab) where {CV<:AbstractRGB}  = cnvt(CV, convert(Lab{eltyp
 cnvt(::Type{CV}, c::LCHuv) where {CV<:AbstractRGB}  = cnvt(CV, convert(Luv{eltype(c)}, c))
 cnvt(::Type{CV}, c::Color3) where {CV<:AbstractRGB}    = cnvt(CV, convert(XYZ{eltype(c)}, c))
 
-cnvt(::Type{CV}, c::RGB24) where {CV<:AbstractRGB{N0f8}} = CV(N0f8(c.color&0x00ff0000>>>16,0), N0f8(c.color&0x0000ff00>>>8,0), N0f8(c.color&0x000000ff,0))
-cnvt(::Type{CV}, c::RGB24) where {CV<:AbstractRGB} = CV((c.color&0x00ff0000>>>16)/255, ((c.color&0x0000ff00)>>>8)/255, (c.color&0x000000ff)/255)
+cnvt(::Type{CV}, c::RGB24) where {CV<:AbstractRGB{N0f8}} = CV(N0f8((c.color&0x00ff0000)>>>16,0), N0f8((c.color&0x0000ff00)>>>8,0), N0f8(c.color&0x000000ff,0))
+cnvt(::Type{CV}, c::RGB24) where {CV<:AbstractRGB} = CV(((c.color&0x00ff0000)>>>16)/255, (((c.color&0x0000ff00))>>>8)/255, (c.color&0x000000ff)/255)
 
 function cnvt(::Type{CV}, c::AbstractGray) where CV<:AbstractRGB
     g = convert(eltype(CV), gray(c))


### PR DESCRIPTION
* remove `__precompile__()` since it's now the default
* Add parentheses to avoid bitshift deprecation warning (which just got turned on by https://github.com/JuliaLang/julia/pull/28389 )