### PR TITLE
Harmonize spelling of "colorspaces"

### DIFF
--- a/docs/src/colorspaces.md
+++ b/docs/src/colorspaces.md
@@ -155,7 +155,7 @@ Three functions are provided that map colors to a reduced gamut to simulate diff
 
 *Protanopia*, *deuteranopia*, and *tritanopia* are the loss of long, middle, and short wavelength photopigment, respectively.
 
-These functions take a color and return a new, altered color in the same colorspace .
+These functions take a color and return a new, altered color in the same colorspace.
 
 ```julia
 protanopic(c::Color, p::Float64)

--- a/docs/src/colorspaces.md
+++ b/docs/src/colorspaces.md
@@ -126,9 +126,9 @@ Options are as follows:
 |`DE_BFD(kl::Float64, kc::Float64)`                      |                                                                   |
 |`DE_BFD()`                                              | - when not specified, the constants default to 1, and the white point defaults to CIED65.                                                                   |
 |`DE_AB()`                                               | Specify the original, Euclidean color difference equation.                                                                                                  |
-|`DE_DIN99()`                                            | Specify the Euclidean color difference equation applied in the `DIN99` uniform color space.                                                                 |
-|`DE_DIN99d()`                                           | Specify the Euclidean color difference equation applied in the `DIN99d` uniform color space.                                                                 |
-|`DE_DIN99o()`                                           | Specify the Euclidean color difference equation applied in the `DIN99o` uniform color space.                                                                 |
+|`DE_DIN99()`                                            | Specify the Euclidean color difference equation applied in the `DIN99` uniform colorspace.                                                                 |
+|`DE_DIN99d()`                                           | Specify the Euclidean color difference equation applied in the `DIN99d` uniform colorspace.                                                                 |
+|`DE_DIN99o()`                                           | Specify the Euclidean color difference equation applied in the `DIN99o` uniform colorspace.                                                                 |
 
 [need docstrings?]
 ```@docs

--- a/docs/src/colorspaces.md
+++ b/docs/src/colorspaces.md
@@ -35,19 +35,19 @@ Depending on the source and destination colorspace, this may not be perfectly lo
 
 ```
 julia> c = colorant"red"
-RGB{N0f8}(1.0,0.0,0.0)
+RGB{N0f8}(1.0, 0.0, 0.0)
 
 julia> parse(Colorant, "red")
-RGB{N0f8}(1.0,0.0,0.0)
+RGB{N0f8}(1.0, 0.0, 0.0)
 
 julia> parse(Colorant, HSL(1, 1, 1))
-HSL{Float32}(1.0f0,1.0f0,1.0f0)
+HSL{Float32}(1.0f0, 1.0f0, 1.0f0)
 
 julia> colorant"#FF0000"
-RGB{N0f8}(1.0,0.0,0.0)
+RGB{N0f8}(1.0, 0.0, 0.0)
 
 julia> parse(Colorant, RGBA(1, 0.5, 1, 0.5))
-RGBA{Float64}(1.0,0.5,1.0,0.5)
+RGBA{Float64}(1.0, 0.5, 1.0, 0.5)
 ```
 
 You can parse any [CSS color specification](https://developer.mozilla.org/en-US/docs/CSS/color) with the exception of `currentColor` (and `rebeccapurple`).
@@ -56,9 +56,9 @@ All CSS/SVG named colors are supported, in addition to X11 named colors, when th
 
 Returns a `RGB{U8}` color, unless:
 
-- `"hsl(h,s,l)"` was used, in which case an `HSL` color is returned
-- `"rgba(r,g,b,a)"` was used, in which case an `RGBA` color is returned
-- `"hsla(h,s,l,a)"` was used, in which case an `HSLA` color is returned
+- `"hsl(h, s, l)"` was used, in which case an `HSL` color is returned
+- `"rgba(r, g, b, a)"` was used, in which case an `RGBA` color is returned
+- `"hsla(h, s, l, a)"` was used, in which case an `HSLA` color is returned
 - a specific `Colorant` type was specified in the first argument
 
 When writing functions the `colorant"red"` version is preferred, because the slow step runs when the code is parsed (i.e., during compilation rather than run-time).
@@ -163,7 +163,7 @@ deuteranopic(c::Color, p::Float64)
 tritanopic(c::Color, p::Float64)
 ```
 
-Also provided are versions of these functions with an extra parameter `p` in `[0,1]`, giving the degree of photopigment loss, where 1.0 is a complete loss, and 0.0 is no loss at all.
+Also provided are versions of these functions with an extra parameter `p` in `[0, 1]`, giving the degree of photopigment loss, where 1.0 is a complete loss, and 0.0 is no loss at all.
 
 ```@docs
 protanopic

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@ This library provides a wide array of functions for dealing with color.
 
 Supported colorspaces include:
 
-- RGB, BGR, RGB1, RGB4, RGB24, plus transparent versions ARGB, RGBA, ABGR, BGRA, and ARGB32,
+- RGB, BGR, RGB1, RGB4, RGB24, plus transparent versions ARGB, RGBA, ABGR, BGRA, and ARGB32
 - HSV, HSL, HSI, plus all 6 transparent variants (AHSV, HSVA, AHSL, HSLA, AHSI, HSIA)
 - XYZ, xyY, LMS and all 6 transparent variants
 - Lab, Luv, LCHab, LCHuv and all 8 transparent variants

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -693,7 +693,7 @@ function cnvt(::Type{DIN99o{T}}, c::Lab) where T
     # Temporary value for chroma
     go = sqrt(eo^2 + fo^2)
     ho = atan(fo,eo)
-    # rotation of the color space by 26°
+    # rotation of the colorspace by 26°
     h  = rad2deg(ho) + 26
 
     # DIN99o chroma (logarithmic compression)

--- a/src/differences.jl
+++ b/src/differences.jl
@@ -385,7 +385,7 @@ function colordiff(ai::Color, bi::Color, m::DE_DIN99)
 
 end
 
-# A color difference formula for the DIN99d uniform color space
+# A color difference formula for the DIN99d uniform colorspace
 function colordiff(ai::Color, bi::Color, m::DE_DIN99d)
 
     a = convert(DIN99d, ai)


### PR DESCRIPTION
Plus a few minor whitespace/punctuation tweaks (in separate commits in case any of them are undesirable).