### PR TITLE
Eliminate duplicate types already defined in ColorTypes.jl

### DIFF
--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -1,10 +1,11 @@
 module Colors
 
-using FixedPointNumbers, ColorTypes, Reexport, Printf
+using FixedPointNumbers
+using Reexport
+using Printf
+
 @reexport using ColorTypes
 
-AbstractGray{T} = Color{T,1}
-using ColorTypes: TransparentGray
 AbstractAGray{C<:AbstractGray,T} = AlphaColor{C,T,2}
 AbstractGrayA{C<:AbstractGray,T} = ColorAlpha{C,T,2}
 Color3{T} = Color{T,3}

--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -8,8 +8,6 @@ using Printf
 
 AbstractAGray{C<:AbstractGray,T} = AlphaColor{C,T,2}
 AbstractGrayA{C<:AbstractGray,T} = ColorAlpha{C,T,2}
-Color3{T} = Color{T,3}
-Transparent4{C<:Color3,T} = TransparentColor{C,T,4}
 
 import Base: ==, +, -, *, /
 import Base: convert, eltype, hex, isless, range, show, typemin, typemax

--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -6,6 +6,7 @@ using Printf
 
 @reexport using ColorTypes
 
+# TODO: why these types are defined here? Can they move to ColorTypes.jl?
 AbstractAGray{C<:AbstractGray,T} = AlphaColor{C,T,2}
 AbstractGrayA{C<:AbstractGray,T} = ColorAlpha{C,T,2}
 
@@ -20,8 +21,6 @@ export weighted_color_mean,
        colordiff, DE_2000, DE_94, DE_JPC79, DE_CMC, DE_BFD, DE_AB, DE_DIN99, DE_DIN99d, DE_DIN99o,
        MSC, sequential_palette, diverging_palette, colormap,
        colormatch, CIE1931_CMF, CIE1964_CMF, CIE1931J_CMF, CIE1931JV_CMF
-
-# atan(x,y) was introduced after 0.7.0-alpha
 
 # Early utilities
 include("utilities.jl")

--- a/src/promotions.jl
+++ b/src/promotions.jl
@@ -2,5 +2,5 @@ Base.promote_rule(::Type{C3}, ::Type{Cgray}) where {C3<:Color3,Cgray<:AbstractGr
 Base.promote_rule(::Type{C3}, ::Type{Cagray}) where {C3<:Color3,Cagray<:AbstractAGray} = alphacolor(base_colorant_type(C3)){promote_type(eltype(C3), eltype(Cagray))}
 Base.promote_rule(::Type{C3}, ::Type{Cgraya}) where {C3<:Color3,Cgraya<:AbstractGrayA} = coloralpha(base_colorant_type(C3)){promote_type(eltype(C3), eltype(Cgraya))}
 
-Base.promote_rule(::Type{C4}, ::Type{Cgray}) where {C4<:Transparent4,Cgray<:AbstractGray} = base_colorant_type(C4){promote_type(eltype(C4), eltype(Cgray))}
-Base.promote_rule(::Type{C4}, ::Type{Cgray}) where {C4<:Transparent4,Cgray<:TransparentGray} = base_colorant_type(C4){promote_type(eltype(C4), eltype(Cgray))}
+Base.promote_rule(::Type{C3}, ::Type{Cgray}) where {C3<:Transparent3,Cgray<:AbstractGray} = base_colorant_type(C3){promote_type(eltype(C3), eltype(Cgray))}
+Base.promote_rule(::Type{C3}, ::Type{Cgray}) where {C3<:Transparent3,Cgray<:TransparentGray} = base_colorant_type(C3){promote_type(eltype(C3), eltype(Cgray))}


### PR DESCRIPTION
This PR eliminates duplicate types defined in ColorTypes.jl. I am submitting another PR for the Images.jl project as well.

Depends on: https://github.com/JuliaGraphics/ColorTypes.jl/pull/111