### PR TITLE
Fix version dependency on ColorTypes

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -17,7 +17,7 @@ version = "0.4.3"
 deps = ["FixedPointNumbers", "Random", "Test"]
 git-tree-sha1 = "b45e62af8eabea138c381c04972c4b25d47e6c69"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.7.3"
+version = "0.7.4"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.7
-ColorTypes 0.7.0
+ColorTypes 0.7.4
 FixedPointNumbers 0.5.0
 Reexport


### PR DESCRIPTION
CC @juliohm. This one will be more painful because we also have to correct METADATA for the 0.9.3 release.