### PR TITLE
Support range(start, stop; kwargs...)

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -58,7 +58,9 @@ function range(start::T; stop::T, length::Integer=100) where T<:Colorant
     return T[weighted_color_mean(w1, start, stop) for w1 in range(1.0,stop=0.0,length=length)]
 end
 
-range(start::T, stop::T; kwargs...) where T<:Colorant = range(start; stop=stop, kwargs...)
+if VERSION >= v"1.1"
+    range(start::T, stop::T; kwargs...) where T<:Colorant = range(start; stop=stop, kwargs...)
+end
 
 if VERSION < v"1.0.0-"
 import Base: linspace

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -58,6 +58,8 @@ function range(start::T; stop::T, length::Integer=100) where T<:Colorant
     return T[weighted_color_mean(w1, start, stop) for w1 in range(1.0,stop=0.0,length=length)]
 end
 
+range(start::T, stop::T; kwargs...) where T<:Colorant = range(start; stop=stop, kwargs...)
+
 if VERSION < v"1.0.0-"
 import Base: linspace
 Base.@deprecate linspace(start::Colorant, stop::Colorant, n::Integer=100) range(start, stop=stop, length=n)

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -51,5 +51,6 @@ using Colors, FixedPointNumbers, Test, InteractiveUtils
         @test linc1c2[end] == c2
         @test linc1c2[22] == Gray(T(0.5))
         @test typeof(linc1c2) == Array{Gray{T},1}
+        @test range(c1,c2,length=43) == range(c1,stop=c2,length=43)
     end
 end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -51,6 +51,8 @@ using Colors, FixedPointNumbers, Test, InteractiveUtils
         @test linc1c2[end] == c2
         @test linc1c2[22] == Gray(T(0.5))
         @test typeof(linc1c2) == Array{Gray{T},1}
-        @test range(c1,c2,length=43) == range(c1,stop=c2,length=43)
+        if VERSION >= v"1.1"
+            @test range(c1,c2,length=43) == range(c1,stop=c2,length=43)
+        end
     end
 end


### PR DESCRIPTION
From Julia 1.1 on, `range(start, stop; kwargs...)` is supported complementary to `range(start; stop, kwargs...)`. This PR adds the former method for `Colorant`s.