### PR TITLE
Add some precompiles

### DIFF
--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -35,4 +35,7 @@ include("colormaps.jl")
 include("display.jl")
 include("colormatch.jl")
 
+include("precompile.jl")
+_precompile_()
+
 end # module

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,29 @@
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    eltypes = (N0f8, N0f16, Float32, Float64)        # eltypes of parametric colors
+    feltypes = (Float32, Float64)                    # floating-point eltypes
+    pctypes = (Gray, RGB, AGray, GrayA, ARGB, RGBA)  # parametric colors
+    cctypes = (Gray24, AGray32, RGB24, ARGB32)       # non-parametric colors
+    # conversions
+    ## to RGB
+    for T in eltypes, F in feltypes, C in (HSV,LCHab,LCHuv,Lab,Luv,XYZ)
+        @assert precompile(Tuple{typeof(convert),Type{RGB{T}},C{F}})
+    end
+    ## to XYZ
+    for T in feltypes, F in feltypes, C in (HSV,LCHab,LCHuv,Lab,Luv,XYZ,RGB)
+        @assert precompile(Tuple{typeof(convert),Type{XYZ{T}},C{F}})
+    end
+    for T in feltypes, F in (N0f8, N0f16)
+        @assert  precompile(Tuple{typeof(convert),Type{XYZ{T}},RGB{F}})
+    end
+    # parse
+    @assert precompile(Tuple{typeof(parse),Type{ColorTypes.Colorant},String})
+    @assert precompile(Tuple{typeof(parse),Type{RGB{N0f8}},String})
+    @assert precompile(Tuple{typeof(parse),Type{RGBA{N0f8}},String})
+    # colordiff
+    for T in eltypes
+        @assert precompile(Tuple{typeof(colordiff),RGB{T},RGB{T}})
+    end
+    @assert precompile(Tuple{typeof(colormap),String})
+    @assert precompile(Tuple{typeof(distinguishable_colors),Int})
+end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -69,7 +69,7 @@ end
 
 #Double quadratic Bezier curve
 function Bezier(t::T, p0::T, p2::T, q0::T, q1::T, q2::T) where T<:Real
-    B(t,a,b,c)=a*(1.0-t)^2.0+2.0b*(1.0-t)*t+c*t^2.0
+    B(t,a,b,c)=a*(1.0-t)^2 + 2.0b*(1.0-t)*t + c*t^2
     if t <= 0.5
         return B(2.0t, p0, q0, q1)
     else #t > 0.5
@@ -79,7 +79,7 @@ end
 
 #Inverse double quadratic Bezier curve
 function invBezier(t::T, p0::T, p2::T, q0::T, q1::T, q2::T) where T<:Real
-    invB(t,a,b,c)=(a-b+sqrt(b^2.0-a*c+(a-2.0b+c)*t))/(a-2.0b+c)
+    invB(t,a,b,c)=(a-b+sqrt(b^2-a*c+(a-2.0b+c)*t))/(a-2.0b+c)
     if t < q1
         return 0.5*invB(t,p0,q0,q1)
     else #t >= q1


### PR DESCRIPTION
This adds some precompile statements to reduce latency. Because the methods are simple to infer, the savings are modest, but combined with precompiles in other packages (FixedPointNumbers, ColorTypes, ColorVectorSpace) I'm getting latency reductions of ~30% for some common operations. So these seem worth having.