### PR TITLE
Support ColorTypes 0.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Colors"
 uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
-version = "0.10.0"
+version = "0.11.0"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
@@ -10,7 +10,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-ColorTypes = "0.7, 0.8"
+ColorTypes = "0.9"
 FixedPointNumbers = "0.6, 0.7"
 Reexport = "0.2"
 julia = "1"

--- a/docs/src/colorspaces.md
+++ b/docs/src/colorspaces.md
@@ -5,7 +5,7 @@
 
 The colorspaces used by Colors are defined in [ColorTypes](https://github.com/JuliaGraphics/ColorTypes.jl). Briefly, the defined spaces are:
 
-- Red-Green-Blue spaces: `RGB`, `BGR`, `RGB1`, `RGB4`, `RGB24`, plus transparent versions `ARGB`, `RGBA`, `ABGR`, `BGRA`, and `ARGB32`.
+- Red-Green-Blue spaces: `RGB`, `BGR`, `XRGB`, `RGBX`, `RGB24`, plus transparent versions `ARGB`, `RGBA`, `ABGR`, `BGRA`, and `ARGB32`.
 
 - `HSV`, `HSL`, `HSI`, plus all 6 transparent variants (`AHSV`, `HSVA`, `AHSL`, `HSLA`, `AHSI`, `HSIA`)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@ This library provides a wide array of functions for dealing with color.
 
 Supported colorspaces include:
 
-- RGB, BGR, RGB1, RGB4, RGB24, plus transparent versions ARGB, RGBA, ABGR, BGRA, and ARGB32
+- RGB, BGR, XRGB, RGBX, RGB24, plus transparent versions ARGB, RGBA, ABGR, BGRA, and ARGB32
 - HSV, HSL, HSI, plus all 6 transparent variants (AHSV, HSVA, AHSL, HSLA, AHSI, HSIA)
 - XYZ, xyY, LMS and all 6 transparent variants
 - Lab, Luv, LCHab, LCHuv and all 8 transparent variants

--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -5,6 +5,8 @@ using Reexport
 using Printf
 
 @reexport using ColorTypes
+Base.@deprecate_binding RGB1 XRGB
+Base.@deprecate_binding RGB4 RGBX
 
 # TODO: why these types are defined here? Can they move to ColorTypes.jl?
 AbstractAGray{C<:AbstractGray,T} = AlphaColor{C,T,2}

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -29,7 +29,7 @@ using ColorTypes: eltype_default, parametric3
         @warn "Optimization in `[invert_]srgb_compand()` may have the opposite effect."
     end
 
-    fractional_types = (RGB, BGR, RGB1, RGB4)  # types that support Fractional
+    fractional_types = (RGB, BGR, XRGB, RGBX)  # types that support Fractional
 
     redF64 = RGB{Float64}(1,0,0)
     redF32 = RGB{Float32}(1,0,0)
@@ -185,11 +185,11 @@ using ColorTypes: eltype_default, parametric3
 
 
     # More AbstractRGB
-    r4 = RGB4(1,0,0)
+    r4 = RGBX(1,0,0)
     @test convert(RGB, r4) == RGB(1,0,0)
     @test convert(RGB{N0f8}, r4) == RGB{N0f8}(1,0,0)
-    @test convert(RGB4{N0f8}, r4) == RGB4{N0f8}(1,0,0)
-    @test convert(RGB4{Float32}, r4) == RGB4{Float32}(1,0,0)
+    @test convert(RGBX{N0f8}, r4) == RGBX{N0f8}(1,0,0)
+    @test convert(RGBX{Float32}, r4) == RGBX{Float32}(1,0,0)
     @test convert(BGR{Float32}, r4) == BGR{Float32}(1,0,0)
 
     # Issue #257


### PR DESCRIPTION
One thing I failed to anticipate is that because this reexports names in ColorTypes, I needed to create new deprecated bindings if I didn't want to cause a depwarn every time the package is loaded. It doesn't appear to cause a conflict, though:
```julia
julia> using ColorTypes

julia> RGB1
WARNING: ColorTypes.RGB1 is deprecated, use XRGB instead.
  likely near REPL[2]:1
XRGB

julia> using Colors

julia> RGB1
WARNING: ColorTypes.RGB1 is deprecated, use XRGB instead.
  likely near REPL[4]:1
XRGB
```
and in a fresh session
```julia
julia> using ColorTypes, Colors

julia> RGB1
WARNING: Colors.RGB1 is deprecated, use XRGB instead.
  likely near REPL[2]:1
XRGB
```

Normally I'd say this is unambiguously a patch release (and that's what I've done here), but since there are the "new" bindings I'd be open to making this a minor bump if others think that's more appropriate. (In packages higher up the hierarchy, supporting these new names will be a patch release.)