### PR TITLE
Add support for specifying the style of `hex`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.11.2"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,6 +15,7 @@ makedocs(
     modules = [Colors],
     format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true",
                              assets = ["assets/resize_svg.js", "assets/favicon.ico"]),
+    checkdocs = :exports,
     sitename = "Colors",
     pages    = Any[
         "Introduction"             => "index.md",

--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -2,7 +2,6 @@ module Colors
 
 using FixedPointNumbers
 using Reexport
-using Printf
 
 @reexport using ColorTypes
 Base.@deprecate_binding RGB1 XRGB
@@ -13,7 +12,7 @@ AbstractAGray{C<:AbstractGray,T} = AlphaColor{C,T,2}
 AbstractGrayA{C<:AbstractGray,T} = ColorAlpha{C,T,2}
 
 import Base: ==, +, -, *, /
-import Base: convert, eltype, hex, isless, range, show, typemin, typemax
+import Base: convert, eltype, isless, range, show, typemin, typemax
 
 # Additional exports, not exported by ColorTypes
 export weighted_color_mean,

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -2,8 +2,101 @@ using Colors, FixedPointNumbers, Test, InteractiveUtils
 
 @testset "Utilities" begin
 
-    @test hex(RGB(1,0.5,0)) == "FF8000"
-    @test hex(RGBA(1,0.5,0,0.25)) == "40FF8000"
+    @testset "hex" begin
+        base_hex = @test_logs (:warn, r"Base\.hex\(c\) has been moved") Base.hex(RGB(1,0.5,0))
+        @test base_hex == hex(RGB(1,0.5,0))
+
+        @test hex(RGB(1,0.5,0)) == "FF8000"
+        rgba = @test_logs (:warn, r"will soon be changed") hex(RGBA(1,0.5,0,0.25))
+        @test rgba == "40FF8000" # TODO: change it to "FF800040"
+        @test hex(ARGB(1,0.5,0,0.25)) == "40FF8000"
+        @test hex(HSV(30,1.0,1.0)) == "FF8000"
+
+        @test hex(RGB(1,0.5,0), :AUTO) == "FF8000"
+        @test hex(RGBA(1,0.5,0,0.25), :AUTO) == "FF800040"
+        @test hex(ARGB(1,0.5,0,0.25), :AUTO) == "40FF8000"
+        @test hex(HSV(30,1.0,1.0), :AUTO) == "FF8000"
+        @test hex(RGB(1,0.5,0), :SomethingUnknown) == "FF8000"
+
+        @test hex(RGB(1,0.5,0), :S) == "FF8000"
+        @test hex(RGBA(1,0.5,0,0.25), :S) == "FF800040"
+        @test hex(ARGB(1,0.5,0,0.25), :S) == "40FF8000"
+        @test hex(RGB(1,0.533,0), :S) == "F80"
+        @test hex(RGBA(1,0.533,0,0.267), :S) == "F804"
+        @test hex(ARGB(1,0.533,0,0.267), :S) == "4F80"
+
+        @test hex(RGB(1,0.5,0), :s) == "ff8000"
+        @test hex(RGBA(1,0.5,0,0.25), :s) == "ff800040"
+        @test hex(ARGB(1,0.5,0,0.25), :s) == "40ff8000"
+        @test hex(RGB(1,0.533,0), :s) == "f80"
+        @test hex(RGBA(1,0.533,0,0.267), :s) == "f804"
+        @test hex(ARGB(1,0.533,0,0.267), :s) == "4f80"
+
+        @test hex(RGB(1,0.5,0), :RGB) == "F80"
+        @test hex(RGBA(1,0.5,0,0.25), :RGB) == "F80"
+        @test hex(ARGB(1,0.5,0,0.25), :RGB) == "F80"
+        @test hex(HSV(30,1.0,1.0), :RGB) == "F80"
+
+        @test hex(RGB(1,0.5,0), :rgb) == "f80"
+        @test hex(RGBA(1,0.5,0,0.25), :rgb) == "f80"
+        @test hex(ARGB(1,0.5,0,0.25), :rgb) == "f80"
+        @test hex(HSV(30,1.0,1.0), :rgb) == "f80"
+
+        @test hex(RGB(1,0.5,0), :ARGB) == "FF80"
+        @test hex(RGBA(1,0.5,0,0.25), :ARGB) == "4F80"
+        @test hex(ARGB(1,0.5,0,0.25), :ARGB) == "4F80"
+        @test hex(HSV(30,1.0,1.0), :ARGB) == "FF80"
+
+        @test hex(RGB(1,0.5,0), :argb) == "ff80"
+        @test hex(RGBA(1,0.5,0,0.25), :argb) == "4f80"
+        @test hex(ARGB(1,0.5,0,0.25), :argb) == "4f80"
+        @test hex(HSV(30,1.0,1.0), :argb) == "ff80"
+
+        @test hex(RGB(1,0.5,0), :RGBA) == "F80F"
+        @test hex(RGBA(1,0.5,0,0.25), :RGBA) == "F804"
+        @test hex(ARGB(1,0.5,0,0.25), :RGBA) == "F804"
+        @test hex(HSV(30,1.0,1.0), :RGBA) == "F80F"
+
+        @test hex(RGB(1,0.5,0), :rgba) == "f80f"
+        @test hex(RGBA(1,0.5,0,0.25), :rgba) == "f804"
+        @test hex(ARGB(1,0.5,0,0.25), :rgba) == "f804"
+        @test hex(HSV(30,1.0,1.0), :rgba) == "f80f"
+
+        @test hex(RGB(1,0.5,0), :rrggbb) == "ff8000"
+        @test hex(RGBA(1,0.5,0,0.25), :rrggbb) == "ff8000"
+        @test hex(ARGB(1,0.5,0,0.25), :rrggbb) == "ff8000"
+        @test hex(HSV(30,1.0,1.0), :rrggbb) == "ff8000"
+
+        @test hex(RGB(1,0.5,0), :RRGGBB) == "FF8000"
+        @test hex(RGBA(1,0.5,0,0.25), :RRGGBB) == "FF8000"
+        @test hex(ARGB(1,0.5,0,0.25), :RRGGBB) == "FF8000"
+        @test hex(HSV(30,1.0,1.0), :RRGGBB) == "FF8000"
+
+        @test hex(RGB(1,0.5,0), :rrggbb) == "ff8000"
+        @test hex(RGBA(1,0.5,0,0.25), :rrggbb) == "ff8000"
+        @test hex(ARGB(1,0.5,0,0.25), :rrggbb) == "ff8000"
+        @test hex(HSV(30,1.0,1.0), :rrggbb) == "ff8000"
+
+        @test hex(RGB(1,0.5,0), :AARRGGBB) == "FFFF8000"
+        @test hex(RGBA(1,0.5,0,0.25), :AARRGGBB) == "40FF8000"
+        @test hex(ARGB(1,0.5,0,0.25), :AARRGGBB) == "40FF8000"
+        @test hex(HSV(30,1.0,1.0), :AARRGGBB) == "FFFF8000"
+
+        @test hex(RGB(1,0.5,0), :aarrggbb) == "ffff8000"
+        @test hex(RGBA(1,0.5,0,0.25), :aarrggbb) == "40ff8000"
+        @test hex(ARGB(1,0.5,0,0.25), :aarrggbb) == "40ff8000"
+        @test hex(HSV(30,1.0,1.0), :aarrggbb) == "ffff8000"
+
+        @test hex(RGB(1,0.5,0), :RRGGBBAA) == "FF8000FF"
+        @test hex(RGBA(1,0.5,0,0.25), :RRGGBBAA) == "FF800040"
+        @test hex(ARGB(1,0.5,0,0.25), :RRGGBBAA) == "FF800040"
+        @test hex(HSV(30,1.0,1.0), :RRGGBBAA) == "FF8000FF"
+
+        @test hex(RGB(1,0.5,0), :rrggbbaa) == "ff8000ff"
+        @test hex(RGBA(1,0.5,0,0.25), :rrggbbaa) == "ff800040"
+        @test hex(ARGB(1,0.5,0,0.25), :rrggbbaa) == "ff800040"
+        @test hex(HSV(30,1.0,1.0), :rrggbbaa) == "ff8000ff"
+    end
 
     # test utility function weighted_color_mean
     parametric2 = [GrayA,AGray32,AGray]


### PR DESCRIPTION
cf. issue #353

Since `Base.hex` is no longer public, this `hex` does not extend it (i.e. this is `Colors.hex`).
Because of the backward compatibility, `hex(c::ColorAlpha)` returns "AARRGGBB" with a depwarn for now.

The new methods are not fully optimized, so the performance improvement is a future task.