### PR TITLE
Re-support parsing the X11 color names with spaces with a depwarn

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -122,6 +122,20 @@ function _parse_colorant(desc::AbstractString)
         return RGBA{N0f8}(0,0,0,0)
     end
 
+    wo_spaces = replace(ldesc, r"(?<=[^ ]{3}) (?=[^ ]{3})" => "")
+    c = get(color_names, wo_spaces, nothing)
+    if c != nothing
+        camel = replace(titlecase(ldesc), " " => "")
+        Base.depwarn(
+            """
+            The X11 color names with spaces are not recommended because they are not allowed in the SVG/CSS.
+            Use "$camel" or "$wo_spaces" instead.
+            """, :parse)
+        return RGB{N0f8}(reinterpret(N0f8, UInt8(c[1])),
+                         reinterpret(N0f8, UInt8(c[2])),
+                         reinterpret(N0f8, UInt8(c[3])))
+    end
+
     error("Unknown color: ", desc)
 end
 
@@ -159,6 +173,10 @@ A literal Colorant will parse according to the `desc` string (usually returning 
 - an `HSLA` color if `hsla(h, s, l, a)` was used
 
 - a specific `Colorant` type as specified in the first argument
+
+!!! note
+    The X11 color names with spaces (e.g. "sea green") are not recommended
+    because they are not allowed in the SVG/CSS.
 """
 Base.parse(::Type{C}, desc::AbstractString) where {C<:Colorant} = _parse_colorant(C, supertype(C), desc)
 Base.parse(::Type{C}, desc::Symbol) where {C<:Colorant} = parse(C, string(desc))

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -14,6 +14,8 @@ using FixedPointNumbers
     @test_throws ErrorException parse(Colorant, "p ink")
     @test parse(Colorant, "transparent") === RGBA{N0f8}(0,0,0,0)
     @test parse(Colorant, "\nSeaGreen ") === RGB{N0f8}(r8(0x2E),r8(0x8B),r8(0x57))
+    seagreen = @test_logs (:warn, r"Use \"SeaGreen\" or \"seagreen\"") parse(Colorant, "sea GREEN")
+    @test seagreen == colorant"seagreen"
 
     # hex-color
     @test parse(Colorant, "#D0FF58") === RGB(r8(0xD0),r8(0xFF),r8(0x58))


### PR DESCRIPTION
This is another solution for the issue #386. (cf. PR #388)

This parser is somewhat loose. For example, "deep skyblue" or "dark golden rod" are acceptable even though they are not the X11 named colors.