### PR TITLE
Speed up grayscale conversion

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -785,7 +785,11 @@ convert(::Type{G}, x::AbstractGray) where {G<:AbstractGray} = G(gray(x))
 
 function convert(::Type{G}, x::AbstractRGB{T}) where {G<:AbstractGray,T<:Normed}
     TU, Tf = FixedPointNumbers.rawtype(T), floattype(T)
-    val = min(typemax(TU), Tf(0.299)*reinterpret(red(x)) + Tf(0.587)*reinterpret(green(x)) + Tf(0.114)*reinterpret(blue(x)))
+    if sizeof(TU) < sizeof(UInt)
+        val = Tf(0.001)*(299*reinterpret(red(x)) + 587*reinterpret(green(x)) + 114*reinterpret(blue(x)))
+    else
+        val = Tf(0.299)*reinterpret(red(x)) + Tf(0.587)*reinterpret(green(x)) + Tf(0.114)*reinterpret(blue(x))
+    end
     return G(reinterpret(T, round(TU, val)))
 end
 convert(::Type{G}, x::AbstractRGB) where {G<:AbstractGray} =

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -176,6 +176,11 @@ using ColorTypes: eltype_default, parametric3
     # Issue #377
     @test convert(Gray, RGB24(1,0,0)) === convert(Gray, RGB(1,0,0)) === Gray{N0f8}(0.298)
     @test convert(Gray24, RGB(1,0,0)) === Gray24(0.298)
+    # Check for roundoff error
+    for N in (N0f8, N0f16, N0f32)
+        @test convert(Gray{N}, RGB{N}(1,1,1)) === Gray{N}(1)
+    end
+    @test gray(convert(Gray{N0f64}, RGB{N0f64}(1,1,1))) ≈ 1.0
 
     # Images issue #382
     @test convert(Gray, RGBA(1,1,1,1)) == Gray(N0f8(1))


### PR DESCRIPTION
As suspected by @kimikage, that defensive `min` takes quite a lot of time. This results in a ~2x speed improvement for elementwise gray conversion.