### PR TITLE
Move promotion rules and some typealiases to ColorTypes.jl v0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
     - linux
 julia:
     - 1.0
-    - 1.2
+    - 1
     - nightly
 notifications:
     email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Colors"
 uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
-version = "0.11.2"
+version = "0.12.0"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
@@ -9,8 +9,8 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-ColorTypes = "0.9"
-FixedPointNumbers = "0.6, 0.7"
+ColorTypes = "0.10"
+FixedPointNumbers = "0.6, 0.7, 0.8"
 Reexport = "0.2"
 julia = "1"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
   - julia_version: 1.0
-  - julia_version: 1.2
+  - julia_version: 1
   - julia_version: latest
 
 platform:

--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -7,9 +7,6 @@ using Reexport
 Base.@deprecate_binding RGB1 XRGB
 Base.@deprecate_binding RGB4 RGBX
 
-# TODO: why these types are defined here? Can they move to ColorTypes.jl?
-AbstractAGray{C<:AbstractGray,T} = AlphaColor{C,T,2}
-AbstractGrayA{C<:AbstractGray,T} = ColorAlpha{C,T,2}
 
 import Base: ==, +, -, *, /
 import Base: convert, eltype, isless, range, show, typemin, typemax
@@ -29,7 +26,6 @@ include("utilities.jl")
 
 # Include other module components
 include("conversions.jl")
-include("promotions.jl")
 include("algorithms.jl")
 include("parse.jl")
 include("differences.jl")

--- a/src/promotions.jl
+++ b/src/promotions.jl
@@ -1,6 +1,0 @@
-Base.promote_rule(::Type{C3}, ::Type{Cgray}) where {C3<:Color3,Cgray<:AbstractGray} = base_colorant_type(C3){promote_type(eltype(C3), eltype(Cgray))}
-Base.promote_rule(::Type{C3}, ::Type{Cagray}) where {C3<:Color3,Cagray<:AbstractAGray} = alphacolor(base_colorant_type(C3)){promote_type(eltype(C3), eltype(Cagray))}
-Base.promote_rule(::Type{C3}, ::Type{Cgraya}) where {C3<:Color3,Cgraya<:AbstractGrayA} = coloralpha(base_colorant_type(C3)){promote_type(eltype(C3), eltype(Cgraya))}
-
-Base.promote_rule(::Type{C3}, ::Type{Cgray}) where {C3<:Transparent3,Cgray<:AbstractGray} = base_colorant_type(C3){promote_type(eltype(C3), eltype(Cgray))}
-Base.promote_rule(::Type{C3}, ::Type{Cgray}) where {C3<:Transparent3,Cgray<:TransparentGray} = base_colorant_type(C3){promote_type(eltype(C3), eltype(Cgray))}

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -5,18 +5,6 @@ using ColorTypes: eltype_default, parametric3
 @testset "Conversion" begin
     r8(x) = reinterpret(N0f8, x)
 
-    # Promotions
-    a, b = promote(RGB(1,0,0), Gray(0.8))
-    @test isa(a, RGB{Float64}) && isa(b, RGB{Float64})
-    a, b = promote(RGBA(1,0,0), Gray(0.8))
-    @test isa(a, RGBA{Float64}) && isa(b, RGBA{Float64})
-    a, b = promote(RGBA(1,0,0), GrayA(0.8))
-    @test isa(a, RGBA{Float64}) && isa(b, RGBA{Float64})
-    a, b = promote(RGB(1,0,0), GrayA(0.8))
-    @test isa(a, RGBA{Float64}) && isa(b, RGBA{Float64})
-    a, b = promote(RGB(1,0,0), AGray(0.8))
-    @test isa(a, ARGB{Float64}) && isa(b, ARGB{Float64})
-
     # srgb_compand / invert_srgb_compand
     @test Colors.srgb_compand(0.5) ≈ 0.7353569830524494 atol=eps()
     @test Colors.invert_srgb_compand(0.7353569830524494) ≈ 0.5 atol=eps()


### PR DESCRIPTION
~We are currently undergoing a major renovation of ColorTypes.jl. So, this PR is a preview.~

Since gray-->rgb conversions were supported and some rgb-->rgb conversions were fixed in ColorTypes.jl v0.10, this PR delegates the conversions to ColorType.jl.