### PR TITLE
Add normalize_hue and Enhance hue handling in `range`

### DIFF
--- a/docs/src/colormapsandcolorscales.md
+++ b/docs/src/colormapsandcolorscales.md
@@ -4,12 +4,14 @@
 
 ### Generating a range of colors
 
-The `range()` function has a method that accepts colors:
+The [`range()`](@ref) function has a method that accepts colors:
 
-`range(start::Color; stop::Color, length=100)`
+```julia
+    Base.range(start::T; stop::T, length=100) where T<:Colorant
+```
 
-This generates `n` colors in a linearly interpolated ramp from `start` to
-`stop`, inclusive, returning an `Array` of colors.
+This generates N (=`length`) colors in a linearly interpolated ramp from `start`
+to `stop`, inclusive, returning an `Array` of colors.
 
 ```jldoctest example
 julia> using Colors
@@ -39,15 +41,33 @@ julia> range(c1, stop=c2, length=15)
  RGB{N0f8}(0.0,0.502,0.0)
 ```
 If you use Julia through Juno or IJulia, you can get the following color swatches.
-```@example
+```@example range
 using Colors # hide
 showable(::MIME"text/plain", ::AbstractVector{C}) where {C<:Colorant} = false # hide
 range(colorant"red", stop=colorant"green", length=15)
 ```
+The intermediate colors depend on their colorspace. For example:
+```@example range
+range(HSL(colorant"red"), stop=HSL(colorant"green"), length=15)
+```
+The [`range`](@ref) and [`weighted_color_mean`](@ref) described below support
+colors with hues which are out of the range [0, 360]. The hues of generated
+colors are normalized into [0, 360].
+```@example range
+range(HSV(0,1,1), stop=HSV(-360,1,1), length=90) # inverse rotation
+```
+```@example range
+range(LCHab(70,70,0), stop=LCHab(70,70,720), length=90) # multiple rotations
+```
+While sometimes useful in particular circumstances, typically it is recommended
+that the hue be within [0, 360]. See [`normalize_hue`](@ref).
 
+```@docs
+Base.range
+```
 ### Weighted color means
 
-The `weighted_color_mean()` function returns a color that is the weighted mean of `c1` and `c2`, where `c1` has a weight 0 ≤ `w1` ≤ 1.
+The [`weighted_color_mean()`](@ref) function returns a color that is the weighted mean of `c1` and `c2`, where `c1` has a weight 0 ≤ `w1` ≤ 1.
 
 For example:
 

--- a/docs/src/constructionandconversion.md
+++ b/docs/src/constructionandconversion.md
@@ -62,6 +62,7 @@ When writing functions the `colorant"red"` version is preferred, because the slo
 
 ```@docs
 @colorant_str
-hex
 parse
+hex
+normalize_hue
 ```

--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -21,6 +21,7 @@ export weighted_color_mean,
        distinguishable_colors, whitebalance,
        colordiff, DE_2000, DE_94, DE_JPC79, DE_CMC, DE_BFD, DE_AB, DE_DIN99, DE_DIN99d, DE_DIN99o,
        MSC, sequential_palette, diverging_palette, colormap,
+       normalize_hue,
        colormatch, CIE1931_CMF, CIE1964_CMF, CIE1931J_CMF, CIE1931JV_CMF, CIE2006_2_CMF, CIE2006_10_CMF
 
 # Early utilities

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -176,7 +176,7 @@ may also be specified.
 function MSC(h)
 
     #Wrap h to [0, 360] range
-    h = mod(h, 360)
+    h = normalize_hue(h)
 
     #Selecting edge of RGB cube; R=1 G=2 B=3
     # p #variable

--- a/src/colormaps.jl
+++ b/src/colormaps.jl
@@ -138,9 +138,9 @@ function sequential_palette(h,
                             dcolor=RGB(0,0,1),
                             logscale=false)
 
-    function MixHue(a,h0,h1)
-        M=mod(180.0+h1-h0, 360)-180.0
-        mod(h0+a*M, 360)
+    function mix_hue(a, h0, h1)
+        m = normalize_hue(180.0 + h1 - h0) - 180.0
+        normalize_hue(h0 + a * m)
     end
     function mix_linearly(a::C, b::C, s) where C<:Color
         base_color_type(C)((1-s)*comp1(a)+s*comp1(b), (1-s)*comp2(a)+s*comp2(b), (1-s)*comp3(a)+s*comp3(b))
@@ -153,13 +153,13 @@ function sequential_palette(h,
 
     #multi-hue start point
     p2l = 100 * (1. - w) + w * pstart.l
-    p2h=MixHue(w,h,pstart.h)
+    p2h=mix_hue(w,h,pstart.h)
     p2c=min(MSC(p2h,p2l), w*s*pstart.c)
     p2=LCHuv(p2l,p2c,p2h)
 
     #multi-hue ending point
     p0l=20.0*d
-    p0h=MixHue(d,h,pend.h)
+    p0h=mix_hue(d,h,pend.h)
     p0c=min(MSC(p0h,p0l), d*s*pend.c)
     p0=LCHuv(p0l,p0c,p0h)
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -100,9 +100,7 @@ function cnvt(::Type{CV}, c::HSV) where CV<:AbstractRGB
 end
 
 function qtrans(u, v, hue)
-    if     hue > 360; hue -= 360
-    elseif hue < 0;   hue += 360
-    end
+    hue = normalize_hue(hue)
 
     if     hue < 60;  u + (v - u) * hue / 60
     elseif hue < 180; v
@@ -123,9 +121,7 @@ function cnvt(::Type{CV}, c::HSL) where CV<:AbstractRGB
 end
 
 function cnvt(::Type{CV}, c::HSI) where CV<:AbstractRGB
-    h, s, i = c.h, c.s, c.i
-    while(h > 360) h -= 360 end
-    while(h < 0) h += 360 end
+    h, s, i = normalize_hue(c.h), c.s, c.i
     is = i*s
     if h < 120
         cosr = cosd(h) / cosd(60-h)
@@ -230,14 +226,7 @@ function cnvt(::Type{HSL{T}}, c::AbstractRGB) where T
         h = convert(T, 4) + (r - g) / (c_max - c_min)
     end
 
-    h *= 60
-    if h < 0
-        h += 360
-    elseif h > 360
-        h -= 360
-    end
-
-    HSL{T}(h,s,l)
+    HSL{T}(normalize_hue(h * 60), s, l)
 end
 
 


### PR DESCRIPTION
This adds a new function `normalize_hue`, which simply wraps the hue angles to [0,360].
This PR does not solve the issue #379, but adding the hue normalization to `weighted_color_mean` helps handle hues in `range`.