### PR TITLE
Re-enable clamping in `hex`

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -73,6 +73,8 @@ end
 correct_gamut(c::CV) where {CV<:AbstractRGB} = CV(clamp01(red(c)), clamp01(green(c)), clamp01(blue(c)))
 correct_gamut(c::CV) where {T<:Union{N0f8,N0f16,N0f32,N0f64},
                             CV<:Union{AbstractRGB{T},TransparentRGB{T}}} = c
+correct_gamut(c::CV) where {CV<:TransparentRGB} =
+    CV(clamp01(red(c)), clamp01(green(c)), clamp01(blue(c)), clamp01(alpha(c))) # for `hex`
 
 function srgb_compand(v::Fractional)
     # the following is an optimization technique for `1.055v^(1/2.4) - 0.055`.

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -96,6 +96,16 @@ using Colors, FixedPointNumbers, Test, InteractiveUtils
         @test hex(RGBA(1,0.5,0,0.25), :rrggbbaa) == "ff800040"
         @test hex(ARGB(1,0.5,0,0.25), :rrggbbaa) == "ff800040"
         @test hex(HSV(30,1.0,1.0), :rrggbbaa) == "ff8000ff"
+
+        @test hex(Gray(0.5)) == "808080"
+        @test hex(AGray(1.0, 0.5), :aarrggbb) == "80ffffff"
+
+        # clamping
+        @test hex(RGB(2.0,-1.0,0.5)) == "FF0080"
+        @test hex(ARGB(2.0,-1.0,0.5,-10), :rrggbbaa) == "ff008000"
+        @test hex(AHSV(30,1.0,1.0,-10), :RRGGBBAA) == "FF800000"
+        @test hex(Gray(2.0)) == "FFFFFF"
+        @test hex(AGray(1.0, -0.5), :rrggbbaa) == "ffffff00"
     end
 
     @testset "normalize_hue" begin


### PR DESCRIPTION
See: https://github.com/JuliaGraphics/Colors.jl/issues/378#issuecomment-588179535

I had forgotten the alpha outside of [0,1].  Although some slowing down is inevitable, it is still faster than pre-PR #387.