### PR TITLE
Add charts for `colordiff` to docs and Use docstrings for metrics

### DIFF
--- a/docs/colordiffcharts.jl
+++ b/docs/colordiffcharts.jl
@@ -1,0 +1,96 @@
+
+module ColorDiffCharts
+
+using Colors
+
+struct ColorDiffChartSVG <: Main.SVG
+    buf::IOBuffer
+end
+
+#               julia_green,       julia_red,         julia_purple
+const c = Lab.([colorant"#389826", colorant"#CB3C33", colorant"#9558B2"])
+
+function ColorDiffChartSVG(metric::Colors.DifferenceMetric)
+    io = IOBuffer()
+
+    id = nameof(typeof(metric))
+
+    d12 = colordiff(c[1], c[2], metric=metric)
+    d23 = colordiff(c[2], c[3], metric=metric)
+    d31 = colordiff(c[3], c[1], metric=metric)
+
+    dn = 2*d31^2 - d23^2 + 2*d12^2
+    ds0 = -(d31-d23-d12) * (d31-d23+d12) * (d31+d23-d12) * (d31+d23+d12)
+    # `ds0` should be non-negative in metric systems.
+    # However, DE_CMC is not metric but quasimetric.
+    ds = max(ds0, 0)
+
+    x = [0,
+         -sqrt(ds/dn)/2,
+          sqrt(ds/dn)/2]
+
+    y = [-sqrt(dn) / 3,
+         (( -d31^2 - d23^2 + 5*d12^2) * sqrt(dn)) / 6dn,
+         ((5*d31^2 - d23^2 -   d12^2) * sqrt(dn)) / 6dn]
+
+    # verification
+    if ds0 >= 0
+        d12 ≈ hypot(x[1] - x[2], y[1] - y[2]) || error("distance mismatch: d12")
+        d23 ≈ hypot(x[2] - x[3], y[2] - y[3]) || error("distance mismatch: d23")
+        d31 ≈ hypot(x[3] - x[1], y[3] - y[1]) || error("distance mismatch: d31")
+    end
+
+    scale = 7.5 / abs(y[1])
+
+    sx = scale .* x
+    sy = scale .* y
+    r = scale * 20
+
+    mx12, my12 = (sx[1] + sx[2]) * 0.5, (sy[1] + sy[2]) * 0.5
+    mx23, my23 = (sx[2] + sx[3]) * 0.5, (sy[2] + sy[3]) * 0.5
+    mx31, my31 = (sx[3] + sx[1]) * 0.5, (sy[3] + sy[1]) * 0.5
+
+    a = atan(sy[2] - sy[3], sx[2] - sx[3])
+    dy23, dx23 = 8 .* sincos(a)
+
+    simplify(x) = replace(string(round(x, sigdigits=3)), r"\.0+$"=>"")
+    rd12, rd23, rd31 = simplify.((d12, d23, d31))
+
+    write(io,
+        """
+        <svg xmlns="http://www.w3.org/2000/svg" version="1.1"
+             viewBox="-15 -12 30 30" width="30mm" height="30mm"
+             stroke="none" stroke-linejoin="round"
+             style="display:inline; margin-left:2em; margin-bottom:2em">
+        <defs>
+          <marker id="marker_s_$id" orient="auto" style="overflow:visible">
+            <path d="M 7,-30 l -7,4 7,4 M 0,-26 h 9 M 0,-3 v -27"
+                  style="fill:none;stroke:currentColor;stroke-opacity:0.7;" />
+          </marker>
+          <marker id="marker_e_$id" orient="auto" style="overflow:visible">
+            <path d="M -7,-30 l 7,4 -7,4 M 0,-26 h -9 M 0,-3 v -27"
+                  style="fill:none;stroke:currentColor;stroke-opacity:0.7;" />
+          </marker>
+        </defs>
+        <g>
+          <circle cx="$(sx[3])" cy="$(sy[3])" fill="#$(hex(c[3]))" r="$r" />
+          <circle cx="$(sx[2])" cy="$(sy[2])" fill="#$(hex(c[2]))" r="$r" />
+          <circle cx="$(sx[1])" cy="$(sy[1])" fill="#$(hex(c[1]))" r="$r" />
+        </g>
+        <g style="stroke:currentColor;stroke-width:0.2;stroke-opacity:0.4;
+           marker-start:url(#marker_s_$id);marker-end:url(#marker_e_$id)">
+          <path d="M$(sx[3]),$(sy[3]) L$(sx[2]),$(sy[2])"/>
+          <path d="M$(sx[2]),$(sy[2]) L$(sx[1]),$(sy[1])"/>
+          <path d="M$(sx[1]),$(sy[1]) L$(sx[3]),$(sy[3])"/>
+        </g>
+        <g fill="currentColor" style="font-size:2.8px;">
+          <text x="$(mx12-3)" y="$my12" text-anchor="end">$rd12</text>
+          <text x="$(mx23+dy23)" y="$(my23-dx23+1)" text-anchor="middle">$rd23</text>
+          <text x="$(mx31+3)" y="$my31" text-anchor="start">$rd31</text>
+          <text x="-14" y="17" style="font-size:2.5px;">$id</text>
+        </g>
+        </svg>""")
+    ColorDiffChartSVG(io)
+end
+
+end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,6 +7,7 @@ function Base.show(io::IO, mime::MIME"image/svg+xml", svg::SVG)
 end
 
 include("crosssectionalcharts.jl")
+include("colordiffcharts.jl")
 include("colormaps.jl")
 include("namedcolorcharts.jl")
 

--- a/docs/src/colordifferences.md
+++ b/docs/src/colordifferences.md
@@ -1,35 +1,84 @@
 # Color Differences
 
-The `colordiff` function gives an approximate value for the difference between two colors.
+The [`colordiff`](@ref) function gives an approximate value for the difference between two colors.
 
 ```jldoctest example; setup = :(using Colors)
-julia> colordiff(colorant"red", parse(Colorant, HSV(360, 0.75, 1)))
-8.178248292426845
+julia> colordiff(colorant"red", colorant"darkred")
+23.754149863643036
+
+julia> colordiff(colorant"red", colorant"blue")
+52.88136782250768
+
+julia> colordiff(HSV(0, 0.75, 0.5), HSL(0, 0.75, 0.5))
+19.48591066257135
 ```
 
-`colordiff(a::Color, b::Color; metric::DifferenceMetric=DE_2000())`
+```julia
+    colordiff(a::Color, b::Color; metric=DE_2000())
+```
 
 Evaluate the [CIEDE2000](http://en.wikipedia.org/wiki/Color_difference#CIEDE2000) color difference formula by default. This gives an approximate measure of the perceptual difference between two colors to a typical viewer. A larger number is returned for increasingly distinguishable colors.
 
-Options for `DifferenceMetric` are as follows:
+Options for `metric` are as follows:
 
-| Option                                                 | Action                                        |
-| ----------                                             | -------                                       |
-|`DE_2000(kl::Float64, kc::Float64, kh::Float64)`        | Specify the color difference using the recommended CIEDE2000 equation, with weighting parameters `kl`, `kc`, and `kh` as provided for in the recommendation.|
-|`DE_2000()`                                             | - when not provided, these parameters default to 1.                                                                                                         |
-|`DE_94(kl::Float64, kc::Float64, kh::Float64)`          | Specify the color difference using the recommended CIEDE94 equation, with weighting parameters `kl`, `kc`, and `kh` as provided for in the recommendation.  |
-|`DE_94()`                                               | - hen not provided, these parameters default to 1.                                                                                                          |
-|`DE_JPC79()`                                            | Specify McDonald's "JP Coates Thread Company" color difference formula.                                                                                     |
-|`DE_CMC(kl::Float64, kc::Float64)`                      | Specify the color difference using the CMC equation, with weighting parameters `kl` and `kc`.                                                               |
-|`DE_CMC()`                                              | - when not provided, these parameters default to 1.                                                                                                         |
-|`DE_BFD(wp::XYZ, kl::Float64, kc::Float64)`             | Specify the color difference using the BFD equation, with weighting parameters `kl` and `kc`. Additionally, a white point can be specified, because the BFD equation must convert between `XYZ` and `LAB` during the computation.|
-|`DE_BFD(kl::Float64, kc::Float64)`                      |                                                                   |
-|`DE_BFD()`                                              | - when not specified, the constants default to 1, and the white point defaults to CIED65.                                                                   |
-|`DE_AB()`                                               | Specify the original, Euclidean color difference equation.                                                                                                  |
-|`DE_DIN99()`                                            | Specify the Euclidean color difference equation applied in the `DIN99` uniform colorspace.                                                                 |
-|`DE_DIN99d()`                                           | Specify the Euclidean color difference equation applied in the `DIN99d` uniform colorspace.                                                                 |
-|`DE_DIN99o()`                                           | Specify the Euclidean color difference equation applied in the `DIN99o` uniform colorspace.                                                                 |
+| Metric             | Summary                                                                       |
+|:-------------------|:------------------------------------------------------------------------------|
+|[`DE_2000`](@ref)   | The color difference using the recommended CIE Delta E 2000 equation.         |
+|[`DE_94`](@ref)     | The color difference using the recommended CIE Delta E 94 equation.           |
+|[`DE_JPC79`](@ref)  | McDonald's "JP Coates Thread Company" color difference formula.               |
+|[`DE_CMC`](@ref)    | The color difference using the CMC l:c equation.                              |
+|[`DE_BFD`](@ref)    | The color difference using the BFD equation.                                  |
+|[`DE_AB`](@ref)     | The original ΔE*, Euclidean color difference equation in the `Lab` colorspace.|
+|[`DE_DIN99`](@ref)  | The Euclidean color difference equation applied in the `DIN99` colorspace.    |
+|[`DE_DIN99d`](@ref) | The Euclidean color difference equation applied in the `DIN99d` colorspace.   |
+|[`DE_DIN99o`](@ref) | The Euclidean color difference equation applied in the `DIN99o` colorspace.   |
+
+
+The following charts show the differences between the three colors for each
+metric with the default parameters:
+```@example diff
+using Colors # hide
+using Main: ColorDiffCharts # hide
+ColorDiffCharts.ColorDiffChartSVG(DE_2000()) # hide
+```
+```@example diff
+ColorDiffCharts.ColorDiffChartSVG(DE_94()) # hide
+```
+```@example diff
+ColorDiffCharts.ColorDiffChartSVG(DE_JPC79()) # hide
+```
+```@example diff
+ColorDiffCharts.ColorDiffChartSVG(DE_CMC()) # hide
+```
+```@example diff
+ColorDiffCharts.ColorDiffChartSVG(DE_BFD()) # hide
+```
+```@example diff
+ColorDiffCharts.ColorDiffChartSVG(DE_AB()) # hide
+```
+```@example diff
+ColorDiffCharts.ColorDiffChartSVG(DE_DIN99()) # hide
+```
+```@example diff
+ColorDiffCharts.ColorDiffChartSVG(DE_DIN99d()) # hide
+```
+```@example diff
+ColorDiffCharts.ColorDiffChartSVG(DE_DIN99o()) # hide
+```
+The difference in the size of circles in the charts above represents the
+difference in the scale. The radii of the circles are all 20 in their scale
+units, so larger circles mean that the metric returns smaller values. Therefore,
+we should not compare the color differences between different metrics.
 
 ```@docs
 colordiff
+DE_2000()
+DE_94()
+DE_JPC79()
+DE_CMC()
+DE_BFD()
+DE_AB()
+DE_DIN99()
+DE_DIN99d()
+DE_DIN99o()
 ```


### PR DESCRIPTION
This update the docs for color differences (cf. https://github.com/JuliaGraphics/Colors.jl/issues/398#issuecomment-591360224).

I changed the example for `colordiff`, i.e. removed the strange `parse`.

I also add a doctest for the difference between an `HSV` color and an `HSL` color. It may help check the PR #407. ~The PR #407 is ready for merging, but there may be room for improvement on the `fma`/`muladd` (cf. https://github.com/JuliaGraphics/Colors.jl/pull/407#discussion_r386098781). So, it is another reasonable option to merge this PR first.~ ~(**Edit:** Either is fine now.)~
PR #407 was merged.