### PR TITLE
Speed up RGB <--> XYZ conversions again

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -14,6 +14,19 @@ end
 # mod6 supports the input `x` in [-2^28, 2^29]
 mod6(::Type{T}, x::Int32) where T = unsafe_trunc(T, x - 6 * ((widemul(x, 0x2aaaaaaa) + Int64(0x20000000)) >> 0x20))
 
+# TODO: move `pow7` from "src/differences.jl" to here
+
+pow3_4(x) = (y = @fastmath(sqrt(x)); y*@fastmath(sqrt(y))) # x^(3/4)
+
+# `pow5_12` is called from `srgb_compand`.
+# `cbrt` generates a function call, so there is little benefit of `@fastmath`.
+pow5_12(x) = pow3_4(x) / cbrt(x) # 5/12 == 1/2 + 1/4 - 1/3 == 3/4 - 1/3
+
+# `pow12_5` is called from `invert_srgb_compand`.
+# x^y ≈ exp(y*log(x)) ≈ exp2(y*log2(y)); the middle form is faster
+@noinline pow12_5(x) = x^2 * exp(0.4 * log(x)) # 12/5 == 2.4 == 2 + 0.4
+
+
 # Linear interpolation in [a, b] where x is in [0,1],
 # or coerced to be if not.
 function lerp(x, a, b)

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -20,14 +20,7 @@ using ColorTypes: eltype_default, parametric3
     # srgb_compand / invert_srgb_compand
     @test Colors.srgb_compand(0.5) ≈ 0.7353569830524494 atol=eps()
     @test Colors.invert_srgb_compand(0.7353569830524494) ≈ 0.5 atol=eps()
-    # issue #351
-    l_pow_x_y() = for i=1:1000; (i/1000)^(1/2.4) end
-    l_exp_y_log_x() = for i=1:1000; exp(1/2.4*log(i/1000)) end
-    l_pow_x_y(); t_pow_x_y = @elapsed l_pow_x_y()
-    l_exp_y_log_x(); t_exp_y_log_x = @elapsed l_exp_y_log_x()
-    if t_exp_y_log_x > t_pow_x_y
-        @warn "Optimization in `[invert_]srgb_compand()` may have the opposite effect."
-    end
+    @test Colors.invert_srgb_compand(0.735357f0) ≈ 0.5f0 atol=eps(Float32)
 
     fractional_types = (RGB, BGR, XRGB, RGBX)  # types that support Fractional
 

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -1,6 +1,22 @@
 using Colors, FixedPointNumbers, Test, InteractiveUtils
 
 @testset "Utilities" begin
+    # issue #351
+    xs = max.(rand(1000), 1e-4)
+    @noinline l_pow_x_y() = for x in xs; x^2.4 end
+    @noinline l_pow12_5() = for x in xs; Colors.pow12_5(x) end
+    l_pow_x_y(); t_pow_x_y = @elapsed l_pow_x_y()
+    l_pow12_5(); t_pow12_5 = @elapsed l_pow12_5()
+    if t_pow12_5 > t_pow_x_y
+        @warn "Optimization technique in `pow12_5` may have the opposite effect."
+    end
+    @noinline l_exp_y_log_x() = for x in xs; exp(1/2.4 * log(x)) end
+    @noinline l_pow5_12() = for x in xs; Colors.pow5_12(x) end
+    l_exp_y_log_x(); t_exp_y_log_x = @elapsed l_exp_y_log_x()
+    l_pow5_12(); t_pow5_12 = @elapsed l_pow5_12()
+    if t_pow5_12 > t_exp_y_log_x
+        @warn "Optimization technique in `pow5_12` may have the opposite effect."
+    end
 
     @testset "hex" begin
         base_hex = @test_logs (:warn, r"Base\.hex\(c\) has been moved") Base.hex(RGB(1,0.5,0))


### PR DESCRIPTION
This was invented five months ago (cf. https://github.com/JuliaGraphics/Colors.jl/issues/351#issuecomment-538997861), and Julia v1.3 was released in the meantime.
SIMD optimization is difficult in RGB <--> XYZ conversions. so this change has no dramatic improvement but is still effective.

closes #351.

**Edit:**
However, if we add the partial support for color gamuts in the near future (e.g. in v0.13), it is a good idea to leave this PR open, because the codes for gamma compression/expansion will be moved to a new file "gamuts.jl" (cf. #412)