### PR TITLE
[RFC/WIP] Add partial support for color gamuts

### DIFF
--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -25,6 +25,7 @@ export weighted_color_mean,
 include("utilities.jl")
 
 # Include other module components
+include("gamuts.jl")
 include("conversions.jl")
 include("algorithms.jl")
 include("parse.jl")

--- a/src/gamuts.jl
+++ b/src/gamuts.jl
@@ -1,0 +1,120 @@
+
+abstract type AbstractGamut end
+
+abstract type AbstractRGBGamut <: AbstractGamut end
+
+absolute_whitepoint(gamut::Type{<:AbstractGamut}) =
+    whitepoint(gamut) * whitepoint_luminance(gamut)
+absolute_blackpoint(gamut::Type{<:AbstractGamut}) =
+    blackpoint(gamut) * blackpoint_luminance(gamut)
+
+luminance_range(gamut::Type{<:AbstractGamut}) =
+    absolute_whitepoint(gamut) - absolute_blackpoint(gamut)
+
+# fallback definitions
+whitepoint(::Type{<:AbstractGamut}) = WP_E
+whitepoint_luminance(::Type{<:AbstractGamut}) = 100.0
+blackpoint(gamut::Type{<:AbstractGamut}) = whitepoint(gamut)
+blackpoint_luminance(::Type{<:AbstractGamut}) = 0.0
+gamma_compand(::Type{<:AbstractGamut}, v::Fractional) = Float64(v)^(1/2.2)
+gamma_expand( ::Type{<:AbstractGamut}, v::Fractional) = Float64(v)^(2.2)
+
+# Define the gamuts as abstract types so that Colors.jl in the future and the
+# users can extend them.
+
+# sRGB
+abstract type Gamut_sRGB <: AbstractRGBGamut end
+primary_red(  ::Type{<:Gamut_sRGB}) = xyY(0.64, 0.33, 1)
+primary_green(::Type{<:Gamut_sRGB}) = xyY(0.30, 0.60, 1)
+primary_blue( ::Type{<:Gamut_sRGB}) = xyY(0.15, 0.06, 1)
+whitepoint(::Type{<:Gamut_sRGB}) = WP_D65
+whitepoint_luminance(::Type{<:Gamut_sRGB}) = 80.0 # cd/m^2
+blackpoint_luminance(::Type{<:Gamut_sRGB}) = 0.2 # cd/m^2
+
+# Adobe RGB (1998)
+abstract type Gamut_AdobeRGB <: AbstractRGBGamut end
+primary_red(  ::Type{<:Gamut_AdobeRGB}) = xyY(0.64, 0.33, 1)
+primary_green(::Type{<:Gamut_AdobeRGB}) = xyY(0.21, 0.71, 1)
+primary_blue( ::Type{<:Gamut_AdobeRGB}) = xyY(0.15, 0.06, 1)
+whitepoint(::Type{<:Gamut_AdobeRGB}) = WP_D65
+whitepoint_luminance(::Type{<:Gamut_AdobeRGB}) = 160.0
+blackpoint_luminance(::Type{<:Gamut_AdobeRGB}) = 0.5557
+
+# original NTSC (1953) gamut
+abstract type Gamut_NTSC <: AbstractRGBGamut end
+primary_red(  ::Type{<:Gamut_NTSC}) = xyY(0.67, 0.33, 1)
+primary_green(::Type{<:Gamut_NTSC}) = xyY(0.21, 0.71, 1)
+primary_blue( ::Type{<:Gamut_NTSC}) = xyY(0.14, 0.08, 1)
+whitepoint(::Type{<:Gamut_NTSC}) = WP_C
+
+# SMPTE-C gamut
+abstract type Gamut_SMPTE_C <: AbstractRGBGamut end
+primary_red(  ::Type{<:Gamut_SMPTE_C}) = xyY(0.630, 0.340, 1)
+primary_green(::Type{<:Gamut_SMPTE_C}) = xyY(0.310, 0.595, 1)
+primary_blue( ::Type{<:Gamut_SMPTE_C}) = xyY(0.155, 0.070, 1)
+whitepoint(::Type{<:Gamut_SMPTE_C}) = WP_D65
+
+
+function gamma_compand(::Type{<:Gamut_sRGB}, v::Fractional)
+    # `pow5_12` is an optimized function to get `v^(1/2.4)`
+    v <= 0.0031308 ? 12.92v : 1.055 * pow5_12(v) - 0.055
+end
+
+@inline function gamma_expand(::Type{<:Gamut_sRGB}, v::Fractional)
+    # `pow12_5` is an optimized function to get `x^2.4`
+    v <= 0.04045 ? 1/12.92 * v : pow12_5(1/1.055 * (v + 0.055))
+end
+
+# lookup table for `N0f8` (the extra two elements are for `Float32` splines)
+const srgb_expand_n0f8 = [gamma_expand(Gamut_sRGB, v/255.0) for v = 0:257]
+
+function gamma_expand(::Type{<:Gamut_sRGB}, v::N0f8)
+    @inbounds srgb_expand_n0f8[reinterpret(UInt8, v) + 1]
+end
+
+@inline function gamma_expand(::Type{<:Gamut_sRGB}, v::Float32)
+    i = unsafe_trunc(Int32, v * 255)
+    (i < 13 || i > 255) && return gamma_expand(Gamut_sRGB, Float64(v))
+    @inbounds y = view(srgb_expand_n0f8, i:i+3)
+    dv = v * 255.0 - i
+    dv == 0.0 && @inbounds return y[2]
+    if v < 0.38857287f0
+        return @fastmath(y[2]+0.5*dv*((-2/3*y[1]- y[2])+(2y[3]-1/3*y[4])+
+                                  dv*((     y[1]-2y[2])+  y[3]-
+                                  dv*(( 1/3*y[1]- y[2])+( y[3]-1/3*y[4]) ))))
+    else
+        return @fastmath(y[2]+0.5*dv*((4y[3]-3y[2])-y[4]+dv*((y[4]-y[3])+(y[2]-y[3]))))
+    end
+end
+
+gamma_compand(::Type{<:Gamut_AdobeRGB}, v::Fractional) = pow256_563(v)
+gamma_expand( ::Type{<:Gamut_AdobeRGB}, v::Fractional) = pow563_256(v)
+
+function mat_rgb_to_xyz(gamut::Type{<:AbstractRGBGamut},
+                        wp::Union{XYZ, xyY}=whitepoint(gamut))
+    pr, pg, pb = primary_red(gamut), primary_green(gamut), primary_blue(gamut)
+    z(c::xyY) = 1 - c.x - c.y # Y == 1
+    m_prim = BigFloat[ pr.x  pg.x  pb.x
+                       pr.y  pg.y  pb.y
+                       z(pr) z(pg) z(pb) ]
+    w = convert(XYZ, wp)
+    sr, sg, sb = inv(m_prim) * [w.x, w.y, w.z] # diag.
+    @inbounds Float64[ m_prim[1,1]*sr m_prim[1,2]*sg m_prim[1,3]*sb
+                       m_prim[2,1]*sr m_prim[2,2]*sg m_prim[2,3]*sb
+                       m_prim[3,1]*sr m_prim[3,2]*sg m_prim[3,3]*sb ]
+end
+
+function mat_xyz_to_rgb(gamut::Type{<:AbstractRGBGamut},
+                        wp::Union{XYZ, xyY}=whitepoint(gamut))
+    Float64.(inv(BigFloat.(mat_rgb_to_xyz(gamut, wp))))
+end
+
+function convert_gamut(c::C,
+                       src::Type{<:AbstractRGBGamut},
+                       dest::Type{<:AbstractRGBGamut}) where C <: AbstractRGB
+    T = floattype(eltype(C))
+    xyz_src = mapc(*, rgb_to_xyz(XYZ{T}, c, src), luminance_range(src))
+    xyz_src_a = xyz_src + absolute_blackpoint(src)
+    xyz_dest = xyz_src_a - absolute_blackpoint(dest)
+    xyz_to_rgb(C, mapc(/, xyz_dest, luminance_range(dest)), dest)
+end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -26,6 +26,25 @@ pow5_12(x) = pow3_4(x) / cbrt(x) # 5/12 == 1/2 + 1/4 - 1/3 == 3/4 - 1/3
 # x^y ≈ exp(y*log(x)) ≈ exp2(y*log2(y)); the middle form is faster
 @noinline pow12_5(x) = x^2 * exp(0.4 * log(x)) # 12/5 == 2.4 == 2 + 0.4
 
+pow256_563(x) = x ^ (256/563)
+pow563_256(x) = x ^ (563/256)
+
+macro mul3x3(M, c1, c2, c3)
+    esc(quote
+        @inbounds ($M[1,1]*$c1 + $M[1,2]*$c2 + $M[1,3]*$c3,
+                   $M[2,1]*$c1 + $M[2,2]*$c2 + $M[2,3]*$c3,
+                   $M[3,1]*$c1 + $M[3,2]*$c2 + $M[3,3]*$c3)
+        end)
+end
+
+macro mul3x3xyz(M, xyz)
+    :(@mul3x3 $(esc(M)) $(esc(xyz)).x $(esc(xyz)).y $(esc(xyz)).z)
+end
+
+macro mul3x3lms(M, lms)
+    :(@mul3x3 $(esc(M)) $(esc(lms)).l $(esc(lms)).m $(esc(lms)).s)
+end
+
 
 # Linear interpolation in [a, b] where x is in [0,1],
 # or coerced to be if not.

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -5,10 +5,10 @@ using ColorTypes: eltype_default, parametric3
 @testset "Conversion" begin
     r8(x) = reinterpret(N0f8, x)
 
-    # srgb_compand / invert_srgb_compand
-    @test Colors.srgb_compand(0.5) ≈ 0.7353569830524494 atol=eps()
-    @test Colors.invert_srgb_compand(0.7353569830524494) ≈ 0.5 atol=eps()
-    @test Colors.invert_srgb_compand(0.735357f0) ≈ 0.5f0 atol=eps(Float32)
+    # sRGB gamma compand/expand
+    @test Colors.gamma_compand(Colors.Gamut_sRGB, 0.5) ≈ 0.7353569830524494 atol=eps()
+    @test Colors.gamma_expand(Colors.Gamut_sRGB, 0.7353569830524494) ≈ 0.5 atol=eps()
+    @test Colors.gamma_expand(Colors.Gamut_sRGB, 0.735357f0) ≈ 0.5f0 atol=eps(Float32)
 
     fractional_types = (RGB, BGR, XRGB, RGBX)  # types that support Fractional
 


### PR DESCRIPTION
This is a preview for the gamuts support. (cf. #372, https://github.com/JuliaGraphics/ColorTypes.jl/pull/140)

Functions for so-called color management will not be implemented for the time being.
I'm going to use them only internally (i.e. without exporting them) as experimental features.

From the experience of the experimental implementation of the chromatic adaptation (#340), I think designing APIs for conversion is quite difficult.
