### PR TITLE
Add a constant for the colors in the Julia logo

### DIFF
--- a/docs/src/namedcolors.md
+++ b/docs/src/namedcolors.md
@@ -65,6 +65,6 @@ NamedColorCharts.ColorChartSVG("grays") # hide
 
 ## Julia logo colors
 
-```docs
+```@docs
 Colors.JULIA_LOGO_COLORS
 ```

--- a/docs/src/namedcolors.md
+++ b/docs/src/namedcolors.md
@@ -62,3 +62,9 @@ NamedColorCharts.ColorChartSVG("grays") # hide
     named colors. There are some unnatural definitions due to the different
     origins. For example, "LightGray" is lighter than "Gray", but "DarkGray" is
     also lighter than "Gray".
+
+## Julia logo colors
+
+```docs
+Colors.JULIA_LOGO_COLORS
+```

--- a/docs/src/namedcolors.md
+++ b/docs/src/namedcolors.md
@@ -64,7 +64,14 @@ NamedColorCharts.ColorChartSVG("grays") # hide
     also lighter than "Gray".
 
 ## Julia logo colors
-
+[`Colors.JULIA_LOGO_COLORS`](@ref) is a `NamedTuple` containing the julia logo
+colors defined in the [julia-logo-graphics](https://github.com/JuliaLang/julia-logo-graphics#color-definitions).
+```@example julialogo
+using Colors # hide
+logocolors = Colors.JULIA_LOGO_COLORS
+showable(::MIME"text/plain", ::AbstractVector{C}) where {C<:Colorant} = false # hide
+[logocolors.blue, logocolors.red, logocolors.green, logocolors.purple]
+```
 ```@docs
 Colors.JULIA_LOGO_COLORS
 ```

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -234,7 +234,7 @@ The keys are approximate descriptions of the hue and do not include black.
 
 Not exported, use as `JULIA_LOGO_COLORS.red` etc.
 """
-const JULIA_LOGO_COLORS = (red = colorant"#ca3c32",
-                           green = colorant"#399746",
-                           blue = colorant"#4d64ae",
-                           purple = colorant"#9259a3")
+const JULIA_LOGO_COLORS = (red = colorant"#cb3c33",
+                           green = colorant"#389826",
+                           blue = colorant"#4063d8",
+                           purple = colorant"#9558b2")

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -226,3 +226,15 @@ end
     Base.depwarn("color(\"$str\") is deprecated, use colorant\"$str\" or parse(Colorant, \"$str\")", :color)
     parse(Colorant, str)
 end
+
+"""
+Colors used in the Julia logo as a `NamedTuple`.
+
+The keys are approximate descriptions of the hue and do not include black.
+
+Not exported, use as `JULIA_LOGO_COLORS.red` etc.
+"""
+const JULIA_LOGO_COLORS = (red = colorant"#ca3c32",
+                           green = colorant"#399746",
+                           blue = colorant"#4d64ae",
+                           purple = colorant"#9259a3")


### PR DESCRIPTION
The colors from the Julia logo are frequently used for various visualizations and logo designs, private or public, so I thought they would be useful in this package.

At the same time, I did not put them in the named colors namespace since they are unique to Julia, not a shared color name space like X11 or SVG (cf [this comment](https://github.com/JuliaGraphics/Colors.jl/issues/361#issuecomment-563033679) by @kimikage). For the same reason, they are not exported, just mentioned in the docs.

Happy to make any changes.

(RGB color codes just extracted from the svg in the JuliaLang/julia repository with Inkscape).