### PR TITLE
Use @test_deprecated for depwarn tests

### DIFF
--- a/test/parse.jl
+++ b/test/parse.jl
@@ -14,7 +14,7 @@ using FixedPointNumbers
     @test_throws ErrorException parse(Colorant, "p ink")
     @test parse(Colorant, "transparent") === RGBA{N0f8}(0,0,0,0)
     @test parse(Colorant, "\nSeaGreen ") === RGB{N0f8}(r8(0x2E),r8(0x8B),r8(0x57))
-    seagreen = @test_logs (:warn, r"Use \"SeaGreen\" or \"seagreen\"") parse(Colorant, "sea GREEN")
+    seagreen = @test_deprecated r"Use \"SeaGreen\" or \"seagreen\"" parse(Colorant, "sea GREEN")
     @test seagreen == colorant"seagreen"
 
     # hex-color

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -19,11 +19,11 @@ using Colors, FixedPointNumbers, Test, InteractiveUtils
     end
 
     @testset "hex" begin
-        base_hex = @test_logs (:warn, r"Base\.hex\(c\) has been moved") Base.hex(RGB(1,0.5,0))
+        base_hex = @test_deprecated r"Base\.hex\(c\) has been moved" Base.hex(RGB(1,0.5,0))
         @test base_hex == hex(RGB(1,0.5,0))
 
         @test hex(RGB(1,0.5,0)) == "FF8000"
-        rgba = @test_logs (:warn, r"will soon be changed") hex(RGBA(1,0.5,0,0.25))
+        rgba = @test_deprecated r"will soon be changed" hex(RGBA(1,0.5,0,0.25))
         @test rgba == "40FF8000" # TODO: change it to "FF800040"
         @test hex(ARGB(1,0.5,0,0.25)) == "40FF8000"
         @test hex(HSV(30,1.0,1.0)) == "FF8000"


### PR DESCRIPTION
In Julia v1.5 series, deprecation warnings are no longer shown by default. Although `Pkg.test` will soon enable the display of deprecation warnings, this changes the method for testing deprecation warnings to make the tests robust.

Apart from that, I think we need to rethink the usage of deprecation warnings (cf. #419).