### PR TITLE
Simplify CompatHelper settings and Add PkgEval badge

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -2,22 +2,14 @@ name: CompatHelper
 
 on:
   schedule:
-    - cron: '00 * * * *'
+    - cron: '00 00 * * *'
   issues:
     types: [opened, reopened]
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        julia-version: [1.2.0]
-        julia-arch: [x86]
-        os: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: ${{ matrix.julia-version }}
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()

--- a/README.md
+++ b/README.md
@@ -3,16 +3,15 @@
 | **Documentation**                       | **Build Status**                          | **Code Coverage**               |
 |:---------------------------------------:|:-----------------------------------------:|:-------------------------------:|
 | [![][docs-stable-img]][docs-stable-url] | [![Build Status][travis-img]][travis-url] | [![][codecov-img]][codecov-url] |
-| [![][docs-latest-img]][docs-latest-url] | [![Build Status][appvey-img]][appvey-url] |                                 |
-|                                         |                                           |                                 |
-|                                         |                                           |                                 |
+| [![][docs-dev-img]][docs-dev-url]       | [![Build Status][appvey-img]][appvey-url] |                                 |
+|                                         | [![PkgEval][pkgeval-img]][pkgeval-url]    |                                 |
 
 This library provides a wide array of functions for dealing with color. This
 includes conversion between colorspaces, measuring distance between colors,
 simulating color blindness, parsing colors, and generating color scales for graphics.
 
-[docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
-[docs-latest-url]: http://juliagraphics.github.io/Colors.jl/latest/
+[docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
+[docs-dev-url]: http://juliagraphics.github.io/Colors.jl/dev/
 
 [docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
 [docs-stable-url]: http://juliagraphics.github.io/Colors.jl/stable/
@@ -22,6 +21,9 @@ simulating color blindness, parsing colors, and generating color scales for grap
 
 [appvey-img]: https://ci.appveyor.com/api/projects/status/trgtxvpfwrhm65w5?svg=true
 [appvey-url]: https://ci.appveyor.com/project/cormullion/colors-jl/branch/master
+
+[pkgeval-img]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/C/Colors.svg
+[pkgeval-url]: https://juliaci.github.io/NanosoldierReports/pkgeval_badges/report.html
 
 [codecov-img]: https://codecov.io/gh/JuliaGraphics/Colors.jl/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/JuliaGraphics/Colors.jl


### PR DESCRIPTION
This removes the "setup-julia" action because we have Julia installed by default.
This schedules the CompatHelper to run once a day. Perhaps we are more familiar with the FixedPointNumbers and ColorTypes than the CompatHelper.:smile:

This also adds the new PkgEval badge. Previously there was a separate "Package Evaluator" column, but I put it in the "Build Status" column.