### PR TITLE
Version 0.12.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Colors"
 uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
-version = "0.12.0"
+version = "0.12.1"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"


### PR DESCRIPTION
I would like to release a patch to make PR #418 available for the end users. The constant introduced in PR #418 have not been exported, so there is no change of the public API. I think there are no compatibility issues since the constant will be used by the end users or "tests" in the downstream packages.

I also want to include PR #421 (or part of it) in v0.12.1. However, the compatibility impact of PR #421 is not clear.

cc: @timholy, @johnnychen94 

**Edit:**
The PR #424 does not change the public API, so it may be included in v0.12.1.

**Edit2:**
Half a month has passed, so I will merge PR #426 and release v0.12.1. (Although PR #426 does not change the source code, it is related with PR #418.)