### PR TITLE
Successfully precompile `_parse_colorant`

### DIFF
--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -33,6 +33,18 @@ include("colormaps.jl")
 include("display.jl")
 include("colormatch.jl")
 
+"""
+Colors used in the Julia logo as a `NamedTuple`.
+
+The keys are approximate descriptions of the hue and do not include black.
+
+Not exported, use as `JULIA_LOGO_COLORS.red` etc.
+"""
+const JULIA_LOGO_COLORS = (red = RGB{N0f8}(0.796, 0.235, 0.2),  # colorant"#cb3c33" blocks precompilation
+                           green = RGB{N0f8}(0.22, 0.596, 0.149),
+                           blue = RGB{N0f8}(0.251, 0.388, 0.847),
+                           purple = RGB{N0f8}(0.584, 0.345, 0.698))
+
 if VERSION >= v"1.1"   # work around https://github.com/JuliaLang/julia/issues/34121
     include("precompile.jl")
     _precompile_()

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -228,15 +228,3 @@ end
     Base.depwarn("color(\"$str\") is deprecated, use colorant\"$str\" or parse(Colorant, \"$str\")", :color)
     parse(Colorant, str)
 end
-
-"""
-Colors used in the Julia logo as a `NamedTuple`.
-
-The keys are approximate descriptions of the hue and do not include black.
-
-Not exported, use as `JULIA_LOGO_COLORS.red` etc.
-"""
-const JULIA_LOGO_COLORS = (red = colorant"#cb3c33",
-                           green = colorant"#389826",
-                           blue = colorant"#4063d8",
-                           purple = colorant"#9558b2")


### PR DESCRIPTION
This is an expensive method to infer (>50ms on my machine) and it
has never precompiled successfully. It turns out that
calling it during module definition makes it non-precompilable.
I am guessing that this is because there end up being backedges
to something in the temporary process that does the precompilation
that is no longer available (perhaps gensyms in macro expansion?).
In any case, avoiding the call works around the problem.