### PR TITLE
fix type instability in weighted_color_mean

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -203,12 +203,11 @@ function weighted_color_mean(w1::Real, c1::C, c2::C) where {Cb <: Union{HSV, HSL
                                                             C <: Union{Cb, AlphaColor{Cb}, ColorAlpha{Cb}}}
     normalize_hue(_weighted_color_mean(w1, c1, c2))
 end
-function _weighted_color_mean(w1::Real, c1::Colorant, c2::Colorant)
+function _weighted_color_mean(w1::Real, c1::Colorant{T1}, c2::Colorant{T2}) where {T1,T2}
     @fastmath min(w1, oneunit(w1) - w1) >= zero(w1) || throw(DomainError(w1, "`w1` must be in [0, 1]"))
-    T = promote_type(eltype(c1), eltype(c2))
-    weight1 = convert(T, w1) # TODO: Consider the need for this
+    weight1 = convert(promote_type(T1, T2), w1) # TODO: Consider the need for this
     weight2 = oneunit(weight1) - weight1
-    mapc((x, y)->convert(T, muladd(weight1, x, weight2 * y)), c1, c2)
+    mapc((x, y) -> convert(promote_type(T1, T2), muladd(weight1, x, weight2 * y)), c1, c2)
 end
 function _weighted_color_mean(w1::Integer, c1::C, c2::C) where C <: Colorant
     (w1 & 0b1) === w1 || throw(DomainError(w1, "`w1` must be in [0, 1]"))

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -186,6 +186,7 @@ using Colors, FixedPointNumbers, Test, InteractiveUtils
                 C == AGray32 && (T=N0f8)
                 c1 = C(T(0),T(1))
                 c2 = C(T(1),T(0))
+                @inferred weighted_color_mean(0.5,c1,c2)
                 @test weighted_color_mean(0.5,c1,c2) == C(T(1)-T(0.5),T(0.5))
             end
         end
@@ -195,11 +196,13 @@ using Colors, FixedPointNumbers, Test, InteractiveUtils
                 if C<:Color
                         c1 = C(T(1),T(1),T(0))
                         c2 = C(T(0),T(1),T(1))
+                    @inferred weighted_color_mean(0.5,c1,c2)
                     @test weighted_color_mean(0.5,c1,c2) == C(T(0.5),T(0.5)+T(1)-T(0.5),T(1)-T(0.5))
                 else
                         C == ARGB32 && (T=N0f8)
                         c1 = C(T(1),T(1),T(0),T(1))
                         c2 = C(T(0),T(1),T(1),T(0))
+                    @inferred weighted_color_mean(0.5,c1,c2)
                     @test weighted_color_mean(0.5,c1,c2) == C(T(0.5),T(0.5)+T(1)-T(0.5),T(1)-T(0.5),T(0.5))
                 end
             end


### PR DESCRIPTION
Removes the use of `convert` inside `mapc` which for some reason isn't type-stable. It isn't needed anyway as the previous conversion of `weighted1` has the same effect.

~~This type instability doesn't have a major performance impact, but makes it difficult to test inference in other packages that use this where type instability does have a major impact.~~

See JuliaGraphics/ColorSchemes.jl#52