### PR TITLE
Version 0.12.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,10 @@
 name = "Colors"
 uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
-version = "0.12.6"
+version = "0.12.7"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
-InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
@@ -15,7 +14,8 @@ Reexport = "0.2, 1.0"
 julia = "1"
 
 [extras]
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["InteractiveUtils", "Test"]

--- a/docs/src/colormapsandcolorscales.md
+++ b/docs/src/colormapsandcolorscales.md
@@ -23,7 +23,7 @@ julia> c2 = colorant"green"
 RGB{N0f8}(0.0,0.502,0.0)
 
 julia> range(c1, stop=c2, length=15)
-15-element Array{RGB{N0f8},1} with eltype RGB{FixedPointNumbers.Normed{UInt8,8}}:
+15-element Array{RGB{N0f8},1} with eltype RGB{FixedPointNumbers.N0f8}:
  RGB{N0f8}(1.0,0.0,0.0)
  RGB{N0f8}(0.929,0.035,0.0)
  RGB{N0f8}(0.859,0.071,0.0)

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -1,4 +1,5 @@
-using Colors, FixedPointNumbers, Test, InteractiveUtils
+using Colors, FixedPointNumbers, Test
+using InteractiveUtils # for `subtypes`
 
 @testset "Utilities" begin
     # issue #351


### PR DESCRIPTION
`InteractiveUtils` is not used (imported) in `module Colors`, and is a standard library. Therefore, it should be safely removed from the `[deps]` section.