### PR TITLE
Implement `showable` to check that all components are finite

### DIFF
--- a/docs/src/colormapsandcolorscales.md
+++ b/docs/src/colormapsandcolorscales.md
@@ -23,7 +23,7 @@ julia> c2 = colorant"green"
 RGB{N0f8}(0.0,0.502,0.0)
 
 julia> range(c1, stop=c2, length=15)
-15-element Array{RGB{N0f8},1} with eltype RGB{FixedPointNumbers.Normed{UInt8,8}}:
+15-element Array{RGB{N0f8},1} with eltype RGB{FixedPointNumbers.N0f8}:
  RGB{N0f8}(1.0,0.0,0.0)
  RGB{N0f8}(0.929,0.035,0.0)
  RGB{N0f8}(0.859,0.071,0.0)

--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -9,7 +9,7 @@ Base.@deprecate_binding RGB4 RGBX
 
 
 import Base: ==, +, -, *, /
-import Base: convert, eltype, isless, range, show, typemin, typemax
+import Base: convert, eltype, isless, range, show, showable, typemin, typemax
 
 # Additional exports, not exported by ColorTypes
 export weighted_color_mean,

--- a/src/display.jl
+++ b/src/display.jl
@@ -6,6 +6,15 @@ const max_height = 150
 const max_swatch_size = 25
 const default_max_swatches = 128 * 128
 
+_isfinite(c::Colorant) = mapreducec(isfinite, &, true, c)
+
+Base.showable(::MIME"image/svg+xml", c::Colorant) = _isfinite(c)
+# Note that ImageShow.jl overloads `showable` for `AbstractMatrix{<:Color}`
+function Base.showable(::MIME"image/svg+xml", cs::Union{AbstractVector{<:Colorant},
+                                                        AbstractMatrix{<:Color}})
+    all(_isfinite, cs)
+end
+
 function Base.show(io::IO, mime::MIME"image/svg+xml", c::Color)
     write_declaration(io, mime)
     write(io,

--- a/test/display.jl
+++ b/test/display.jl
@@ -1,4 +1,22 @@
+using Test, Colors
+using FixedPointNumbers
+
 @testset "Display" begin
+    @testset "showable" begin
+        @test showable("image/svg+xml", RGB24(1, 0.5, 0))
+        @test showable("image/svg+xml", Lab(50.0, 0.0, NaN)) === false
+        @test showable("image/svg+xml", colormap("Reds", 4))
+        @test showable("image/svg+xml", [HSVA(30, 1, 1, a) for a = 0.0:0.1:1.0])
+        @test showable("image/svg+xml", [rand(Gray, 4); Gray(Inf)]) === false
+        @test showable("image/svg+xml", rand(RGB, 2, 2))
+        @test showable("image/svg+xml", rand(ARGB, 2, 2)) === false
+        @test showable("image/svg+xml", rand(HSV, 2, 2, 2)) === false
+        @test showable("image/svg+xml", Color[RGB(0, 0, 0) HSV(0, 0, 0);
+                                              XYZ(0, 0, 0) Luv(0, 0, 0)])
+        @test showable("image/svg+xml", Color[RGB(0, 0, 0) HSV(0, 0, 0);
+                                              XYZ(0, 0, 0) Luv(0, 0, NaN)]) === false
+    end
+
     function count_element(pattern::Regex, svg::AbstractString)
         n = 0
         i = firstindex(svg)


### PR DESCRIPTION
This is useful to avoid conversion errors in advance.
Since `NaN`/`Inf` may be caused by bugs, implicit clamping is not performed. This is in contrast to clamping for out-of-gamut colors.

Closes #469.