### PR TITLE
Version 0.12.8

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -17,9 +17,10 @@ jobs:
       matrix:
         julia-version: ['1.0', '1', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]
+      fail-fast: false
 
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
         with:
@@ -30,7 +31,7 @@ jobs:
         env:
           cache-name: cache-artifacts
         with:
-          path: ~/.julia/artifacts 
+          path: ~/.julia/artifacts
           key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
           restore-keys: |
             ${{ runner.os }}-test-${{ env.cache-name }}-

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Colors"
 uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
-version = "0.12.7"
+version = "0.12.8"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
@@ -8,7 +8,7 @@ FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-ColorTypes = "0.10"
+ColorTypes = "0.10, 0.11"
 FixedPointNumbers = "0.6, 0.7, 0.8"
 Reexport = "0.2, 1.0"
 julia = "1"

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -7,23 +7,23 @@ function _precompile_()
     # conversions
     ## to RGB
     for T in eltypes, F in feltypes, C in (HSV,LCHab,LCHuv,Lab,Luv,XYZ)
-        @assert precompile(Tuple{typeof(convert),Type{RGB{T}},C{F}})
+        precompile(Tuple{typeof(convert),Type{RGB{T}},C{F}})
     end
     ## to XYZ
     for T in feltypes, F in feltypes, C in (HSV,LCHab,LCHuv,Lab,Luv,XYZ,RGB)
-        @assert precompile(Tuple{typeof(convert),Type{XYZ{T}},C{F}})
+        precompile(Tuple{typeof(convert),Type{XYZ{T}},C{F}})
     end
     for T in feltypes, F in (N0f8, N0f16)
-        @assert  precompile(Tuple{typeof(convert),Type{XYZ{T}},RGB{F}})
+        precompile(Tuple{typeof(convert),Type{XYZ{T}},RGB{F}})
     end
     # parse
-    @assert precompile(Tuple{typeof(parse),Type{ColorTypes.Colorant},String})
-    @assert precompile(Tuple{typeof(parse),Type{RGB{N0f8}},String})
-    @assert precompile(Tuple{typeof(parse),Type{RGBA{N0f8}},String})
+    precompile(Tuple{typeof(parse),Type{ColorTypes.Colorant},String})
+    precompile(Tuple{typeof(parse),Type{RGB{N0f8}},String})
+    precompile(Tuple{typeof(parse),Type{RGBA{N0f8}},String})
     # colordiff
     for T in eltypes
-        @assert precompile(Tuple{typeof(colordiff),RGB{T},RGB{T}})
+        precompile(Tuple{typeof(colordiff),RGB{T},RGB{T}})
     end
-    @assert precompile(Tuple{typeof(colormap),String})
-    @assert precompile(Tuple{typeof(distinguishable_colors),Int})
+    precompile(Tuple{typeof(colormap),String})
+    precompile(Tuple{typeof(distinguishable_colors),Int})
 end

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -193,6 +193,7 @@ end
 
     # Issue #257
     c = RGB{Float16}(0.9473,0.962,0.9766)
+    convert(HSI, c)
     hsi = convert(HSI, c)
     @test hsi.i > 0.96 && hsi.h ≈ 210
 


### PR DESCRIPTION
This adds the support for [ColorTypes v0.11](https://github.com/JuliaGraphics/ColorTypes.jl/pull/231). The changes in ColorTypes v0.11 are mainly related to ColorVectorSpace, and do not directly affect the Colors.jl API.
This also modifies the CI settings and removes `@assert`s from the precompilation script.