### PR TITLE
Add support for `weighted_color_mean` for multiple colors

### DIFF
--- a/docs/src/colormapsandcolorscales.md
+++ b/docs/src/colormapsandcolorscales.md
@@ -72,8 +72,18 @@ The [`weighted_color_mean()`](@ref) function returns a color that is the weighte
 For example:
 
 ```jldoctest example
-julia> weighted_color_mean(0.5, colorant"red", colorant"green")
-RGB{N0f8}(0.502,0.251,0.0)
+julia> weighted_color_mean(0.8, colorant"red", colorant"green")
+RGB{N0f8}(0.8,0.102,0.0)
+```
+You can also get the weighted mean of three or more colors by passing the
+collections of weights and colors. The following is an example of bilinear
+interpolation.
+
+```@example mean
+using Colors # hide
+[weighted_color_mean([(1-s)*(1-t), s*(1-t), (1-s)*t, s*t], # collection of weights
+                     Colors.JULIA_LOGO_COLORS)             # collection of colors
+                            for s = 0:0.2:1, t = 0:0.05:1]
 ```
 
 ```@docs

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -217,6 +217,43 @@ function _weighted_color_mean(w1::Integer, c1::C, c2::C) where C <: Colorant
 end
 
 """
+    weighted_color_mean(weights, colors)
+
+Returns the weighted mean of the given collection `colors` with `weights`.
+This is semantically equivalent to the calculation of `sum(weights .* colors)`.
+
+# Examples
+```jldoctest; setup = :(using Colors, FixedPointNumbers)
+julia> rgbs = (RGB(1, 0, 0), RGB(0, 1, 0), RGB(0, 0, 1));
+
+julia> weighted_color_mean([0.2, 0.2, 0.6], rgbs)
+RGB{N0f8}(0.2,0.2,0.6)
+
+julia> weighted_color_mean(0.5:-0.25:0.0, RGB{Float64}.(rgbs))
+RGB{Float64}(0.5,0.25,0.0)
+```
+
+!!! compat "Colors v0.13"
+    `wighted_color_mean` with collection or iterator inputs requires Colors
+    v0.13 or later.
+
+!!! note
+    In a cylindrical color space such as HSV, a weighted mean of more than three
+    colors is generally not meaningful.
+"""
+function weighted_color_mean(weights, colors)
+    if length(weights) != length(colors)
+        throw(DimensionMismatch("`weights` and `colors` must be the same length."))
+    end
+    w1, c1 = first(weights), first(colors)
+    acc = mapc(_ -> zero(promote_type(typeof(w1), Float32)), c1)
+    for (w, c) in zip(weights, colors)
+        acc = mapc((a, v) -> a + w * v, acc, c)
+    end
+    convert(typeof(c1), acc)
+end
+
+"""
     range(start::T; stop::T, length=100) where T<:Colorant
     range(start::T, stop::T; length=100) where T<:Colorant
 

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -221,22 +221,38 @@ using InteractiveUtils # for `subtypes`
         lchuva1 = LCHuvA{Float16}(0,100, 90,1)
         lchuva2 = LCHuvA{Float16}(100,0,810,0)
         @test weighted_color_mean(0.5, lchuva1, lchuva2) === LCHuvA{Float16}(50,50,90,0.5)
+
+        @testset "with collections" begin
+            colors = [RGBA(1, 0, 0, 1) RGBA(0, 0, 1, 1)
+                      RGBA(0, 1, 0, 1) RGBA(0, 0, 0, 0)]
+            c = RGBA{N0f8}(0.1, 0.2, 0.3, 0.6)
+            @test weighted_color_mean([0.1 0.3; 0.2 0.4],   colors) === c # matrix
+            @test weighted_color_mean((0.1, 0.2, 0.3, 0.4), colors) === c # tuple
+            @test weighted_color_mean(0.1:0.1:0.4,          colors) === c # range
+
+            @test weighted_color_mean((0, 1), (Gray(1), Gray(0.0))) === Gray{N0f8}(0)
+            @test weighted_color_mean((1, 0), (Gray(1.0), Gray(0))) === Gray{Float64}(1)
+
+            @test_throws DimensionMismatch weighted_color_mean((0.1, 0.2, 0.3), colors)
+            @test_throws Exception weighted_color_mean((0.1, 0.2), (RGB(1, 1, 1), HSV(0, 1, 1)))
+        end
     end
 
-    # test utility function range
-    # range uses weighted_color_mean which is extensively tested.
-    # Therefore it suffices to test the function using gray colors.
-    for T in colorElementTypes
-        c1 = Gray(T(1))
-        c2 = Gray(T(0))
-        linc1c2 = range(c1,stop=c2,length=43)
-        @test length(linc1c2) == 43
-        @test linc1c2[1] == c1
-        @test linc1c2[end] == c2
-        @test linc1c2[22] == Gray(T(0.5))
-        @test typeof(linc1c2) == Array{Gray{T},1}
-        if VERSION >= v"1.1"
-            @test range(c1,c2,length=43) == range(c1,stop=c2,length=43)
+    @testset "range" begin
+        # `range` uses `weighted_color_mean` which is extensively tested.
+        # Therefore it suffices to test the function using gray colors.
+        for T in colorElementTypes
+            c1 = Gray(T(1))
+            c2 = Gray(T(0))
+            linc1c2 = range(c1,stop=c2,length=43)
+            @test length(linc1c2) == 43
+            @test linc1c2[1] == c1
+            @test linc1c2[end] == c2
+            @test linc1c2[22] == Gray(T(0.5))
+            @test typeof(linc1c2) == Array{Gray{T},1}
+            if VERSION >= v"1.1"
+                @test range(c1,c2,length=43) == range(c1,stop=c2,length=43)
+            end
         end
     end
 end


### PR DESCRIPTION
This adds a method of `weighted_color_mean` which takes collections of weights and colors. This is not efficient or accurate implementation, but it is simple.

![weighted_color_mean](https://user-images.githubusercontent.com/12679384/116999880-3a5fa100-ad1b-11eb-9637-9052c8b3dbf8.png)

Closes #467, cc: @cjwyett