### PR TITLE
Change the default alpha position for `hex(::ColorAlpha)`

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -95,30 +95,9 @@ julia> hex(ARGB(1,0.533,0,0.267), :S)
 
 !!! compat "Colors v0.12"
     `style` requires at least Colors v0.12.
-
-!!! compat
-    For backward compatibility, `hex(c::ColorAlpha)` currently returns an
-    "AARRGGBB" style string. This is inconsistent with `hex(c, :AUTO)` returning
-    an "RRGGBBAA" style string. The alpha position for `ColorAlpha` will soon be
-    changed to the tail.
 """
 hex(c::Colorant) = _hex(HexAuto, c) # there is no need to search the dictionary
 hex(c::Colorant, style::Symbol) = _hex(get(_hex_styles, style, HexAuto), c)
-
-function Base.hex(c::Colorant)
-    Base.depwarn("Base.hex(c) has been moved to the package Colors.jl, i.e. Colors.hex(c).", :hex)
-    hex(c)
-end
-
-# TODO: abolish the transitional measure (i.e. remove the following method)
-function hex(c::ColorAlpha)
-    Base.depwarn("""
-        The alpha position for $(typeof(c)) (<:ColorAlpha) will soon be changed.
-        You can get the alpha-first style string by `hex(c, :AARRGGBB)` or `hex(c |> ARGB32)`.
-        """, :hex)
-    #_hex(HexNotation{RGBA,:upper,8}, c) # breaking change in v1.0
-    _hex( HexNotation{ARGB,:upper,8}, c) # backward compatible
-end
 
 const _hex_styles = Dict{Symbol, Type}(
     :AUTO => HexAuto,

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -20,12 +20,8 @@ using InteractiveUtils # for `subtypes`
     end
 
     @testset "hex" begin
-        base_hex = @test_logs (:warn, r"Base\.hex\(c\) has been moved") Base.hex(RGB(1,0.5,0))
-        @test base_hex == hex(RGB(1,0.5,0))
-
         @test hex(RGB(1,0.5,0)) == "FF8000"
-        rgba = @test_logs (:warn, r"will soon be changed") hex(RGBA(1,0.5,0,0.25))
-        @test rgba == "40FF8000" # TODO: change it to "FF800040"
+        @test hex(RGBA(1,0.5,0,0.25)) == "FF800040"
         @test hex(ARGB(1,0.5,0,0.25)) == "40FF8000"
         @test hex(HSV(30,1.0,1.0)) == "FF8000"
 


### PR DESCRIPTION
`hex(::ColorAlpha)` will now return "RRGGBBAA".
This also removes the deprecated `Base.hex(::Colorant)`.

I had expected that reaching v1.0 would happen somewhat sooner, but it has been a year since the release of v0.12.0.:sweat_smile: So, I think this should be applied in v0.13.0.

