### PR TITLE
Use `Float32` for the matrix coefficients for low precision colors

### DIFF
--- a/docs/src/colordifferences.md
+++ b/docs/src/colordifferences.md
@@ -4,13 +4,13 @@ The [`colordiff`](@ref) function gives an approximate value for the difference b
 
 ```jldoctest example; setup = :(using Colors)
 julia> colordiff(colorant"red", colorant"darkred")
-23.754149450423807
+23.75414245117878
 
 julia> colordiff(colorant"red", colorant"blue")
-52.88136496280975
+52.88135569435472
 
 julia> colordiff(HSV(0, 0.75, 0.5), HSL(0, 0.75, 0.5))
-19.48591066257134
+19.485908737785326
 ```
 
 ```julia

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -206,13 +206,8 @@ function MSC(h)
     # un & vn are calculated based on reference white (D65)
     un, vn = xyz_to_uv(WP_DEFAULT)
 
-    #sRGB matrix
-    M = [0.4124564  0.3575761  0.1804375;
-         0.2126729  0.7151522  0.0721750;
-         0.0193339  0.1191920  0.9503041]
-
-    m_tx, m_ty, m_tz = @view M[:, t]
-    m_px, m_py, m_pz = @view M[:, p]
+    m_tx, m_ty, m_tz = @view M_RGB2XYZ[:, t]
+    m_px, m_py, m_pz = @view M_RGB2XYZ[:, p]
 
     f1 = 4alpha*m_px+9beta*m_py
     a1 = 4alpha*m_tx+9beta*m_ty

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -136,13 +136,13 @@ end
     @test convert(HSL, RGB{N0f8}(0.678, 0.847, 0.902)) ≈ HSL{Float32}(194.73685f0,0.5327105f0,0.7901961f0) atol=100eps(Float32)
 
     # YIQ
-    @test convert(YIQ, RGB(1,0,0)) == YIQ{Float32}(0.299, 0.595716, 0.211456)
-    @test convert(YIQ, RGB(0,1,0)) == YIQ{Float32}(0.587, -0.274453, -0.522591)
-    @test convert(YIQ, RGB(0,0,1)) == YIQ{Float32}(0.114, -0.321263, 0.311135)
+    @test convert(YIQ, RGB(1, 0, 0)) ≈ YIQ{Float32}(0.299, 0.595716, 0.211456) atol=1e-7
+    @test convert(YIQ, RGB(0, 1, 0)) ≈ YIQ{Float32}(0.587, -0.274453, -0.522591) atol=1e-7
+    @test convert(YIQ, RGB(0, 0, 1)) ≈ YIQ{Float32}(0.114, -0.321263, 0.311135) atol=1e-7
     @test convert(RGB, YIQ(1.0,0.0,0.0)) == RGB(1,1,1)
-    v = 0.5957
+    v = 0.595716
     @test convert(RGB, YIQ(0.0,1.0,0.0)) == RGB(0.9563*v,0,0)
-    v = -0.5226
+    v = -0.522591
     @test convert(RGB, YIQ(0.0,0.0,-1.0)) == RGB(0,-0.6474*v,0)
 
     # Gray

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -2,6 +2,13 @@ using Colors, FixedPointNumbers, Test
 using InteractiveUtils # for `subtypes`
 
 @testset "Utilities" begin
+    @testset "Mat3x3" begin
+        M3x3 = Colors.Mat3x3([1 2 3; 4 5 6; 7 8 9])
+        @test @inferred(M3x3[4]) === 2
+        @test @inferred(M3x3[2,3]) === 6
+        @test @inferred(M3x3[CartesianIndex(3, 2)]) === 8
+    end
+
     @test Colors.cbrt01(0.6) ≈ cbrt(big"0.6") atol=eps(1.0)
     @test Colors.cbrt01(0.6f0) === cbrt(0.6f0)
 


### PR DESCRIPTION
This also changes the definition of the sRGB transform matrix slightly. (cf. https://github.com/JuliaGraphics/Colors.jl/issues/355#issuecomment-539524932)

cf. #477