### PR TITLE
Improve speed of `pow5_12(::Float64)` and accuracy of `pow5_12(::Float32)`

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -87,9 +87,11 @@ correct_gamut(c::CV) where {T<:Union{N0f8,N0f16,N0f32,N0f64},
 correct_gamut(c::CV) where {CV<:TransparentRGB} =
     CV(clamp01(red(c)), clamp01(green(c)), clamp01(blue(c)), clamp01(alpha(c))) # for `hex`
 
-function srgb_compand(v::Fractional)
+@inline function srgb_compand(v)
+    F = typeof(0.5 * v)
+    vf = F(v)
     # `pow5_12` is an optimized function to get `v^(1/2.4)`
-    v <= 0.0031308 ? 12.92v : 1.055 * pow5_12(v) - 0.055
+    vf > F(0.0031308) ? muladd(F(1.055), F(pow5_12(vf)), F(-0.055)) : F(12.92) * vf
 end
 
 function _hsx_to_rgb(im::UInt8, v, n, m)

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -19,6 +19,9 @@ using InteractiveUtils # for `subtypes`
         @warn "Optimization technique in `pow5_12` may have the opposite effect."
     end
 
+    @test Colors.pow5_12(0.6) ≈ Colors.pow5_12(big"0.6") atol=1e-6
+    @test Colors.pow5_12(0.6f0) ≈ Colors.pow5_12(big"0.6") atol=1e-6
+    @test Colors.pow5_12(0.6N0f16) ≈ Colors.pow5_12(big"0.6") atol=1e-6
     @test Colors.pow12_5(0.6) ≈ Colors.pow12_5(big"0.6") atol=1e-6
     @test Colors.pow12_5(0.6N0f16) ≈ Colors.pow12_5(big"0.6") atol=1e-6
 


### PR DESCRIPTION
`pow5_12` is used in the `XYZ{Float64}`-->`RGB` conversion.
This ensures sufficient accuracy (~3 ULP) in the range of [0.003, 1], which is typically required for the conversion.

`@inline` could be a workaround for the problem with precompilation.

I am planning a `Float32` version. However, for now (i.e. without PR #482), the result will be promoted to `Float64` within the transform matrix.
**Edit:** see https://github.com/JuliaGraphics/Colors.jl/pull/485#issuecomment-856727816

cf. #483