### PR TITLE
Improve `Lab`<-->`XYZ` conversions

### DIFF
--- a/docs/src/colordifferences.md
+++ b/docs/src/colordifferences.md
@@ -4,13 +4,13 @@ The [`colordiff`](@ref) function gives an approximate value for the difference b
 
 ```jldoctest example; setup = :(using Colors)
 julia> colordiff(colorant"red", colorant"darkred")
-23.75414986364304
+23.754149450423807
 
 julia> colordiff(colorant"red", colorant"blue")
-52.88136782250768
+52.88136496280975
 
 julia> colordiff(HSV(0, 0.75, 0.5), HSL(0, 0.75, 0.5))
-19.48591066257134
+19.485910662571342
 ```
 
 ```julia


### PR DESCRIPTION
This adds the separate methods for omitting the white points to facilitate constant folding.
This also suppresses the promotion of intermediate variables to `Float64` due to white point being `XYZ{Float64}`. (cf. issue #477)

A part of this PR has been separated from PR #482.

I'm not sure of the reason, but I avoid `mapc` for now because it makes the precompilation problem worse. This PR does not solve the precompilation problem. :confused: