### PR TITLE
Reduce rounding errors in `delta_h`

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -249,7 +249,8 @@ function delta_h(a::C, b::C) where {Cb <: Union{Lab, Luv},
 end
 function delta_h(a::C, b::C) where {Cb <: Union{LCHab, LCHuv},
                                     C <: Union{Cb, AlphaColor{Cb}, ColorAlpha{Cb}}}
-    sh = @fastmath (hue(a) - hue(b) + 180) / 360
+    dh0 = hue(a) - hue(b)
+    sh = muladd(dh0, oftype(dh0, 1 / 360), oftype(dh0, 0.5))
     d =  @fastmath sh - floor(sh) - oftype(sh, 0.5)
     2 * sqrt(chroma(a) * chroma(b)) * sinpi(d)
 end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -177,10 +177,11 @@ using InteractiveUtils # for `subtypes`
     end
 
     @testset "delta_h" begin
-        @test @inferred(Colors.delta_h(LCHab(50, 60, 70), LCHab(90, 80, 70))) === 0.0f0
+        @test @inferred(Colors.delta_h(LCHab(50, 60, 135.123f0), LCHab(90, 80, 135.123f0))) === 0.0f0
         @test @inferred(Colors.delta_h(LCHuv(50, 60, 80), LCHuv(90,  0, 70))) === 0.0f0
         @test @inferred(Colors.delta_h(LCHab(50, 60, 70), LCHab(90, 80, 190))) ≈ -120.0f0
         @test @inferred(Colors.delta_h(LCHab(90, 80, 70), LCHab(50, 60, 310.0))) ≈ 120.0
+        @test_throws DomainError Colors.delta_h(LCHab(50, -1f-9, 70), LCHab(50, 60, 70))
         @test @inferred(Colors.delta_h(Lab(50, -10, 10), Lab(50, 10, -10))) ≈ 28.284271f0
         @test @inferred(Colors.delta_h(ALuv(50, 0, 0), ALuv(50, 0, 10))) === 0.0f0
     end


### PR DESCRIPTION
`Colors.delta_h` has been introduced in the PR #476.

```julia
julia> Colors.delta_h(LCHab(50, 60, 135.123f0), LCHab(90, 80, 135.123f0))
0.0f0         # master (Julia v1.6.1)
-1.2973305f-5 # master (Julia v1.0.5)
0.0f0         # this PR
```