### PR TITLE
Make the cube root to be inlined

### DIFF
--- a/docs/src/colordifferences.md
+++ b/docs/src/colordifferences.md
@@ -10,7 +10,7 @@ julia> colordiff(colorant"red", colorant"blue")
 52.88136496280975
 
 julia> colordiff(HSV(0, 0.75, 0.5), HSL(0, 0.75, 0.5))
-19.485910662571342
+19.48591066257134
 ```
 
 ```julia

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -437,10 +437,11 @@ cnvt(::Type{xyY{T}}, c::Color) where {T} = cnvt(xyY{T}, convert(XYZ{T}, c))
 # Everything to Lab
 # -----------------
 
-function fxyz2lab(v)
+@inline function fxyz2lab(v)
     ka = oftype(v, 841 / 108) # (29/6)^2 / 3 = xyz_kappa / 116
     kb = oftype(v, 16 / 116) # 4/29
-    v > oftype(v, xyz_epsilon) ? cbrt(v) : muladd(ka, v, kb)
+    vc = @fastmath max(v, oftype(v, xyz_epsilon))
+    @fastmath min(cbrt01(vc), muladd(ka, v, kb))
 end
 @inline function xyz2lab(::Type{Lab{T}}, c::XYZ) where T
     f = XYZ(fxyz2lab(c.x), fxyz2lab(c.y), fxyz2lab(c.z)) # mapc(fxyz2lab, c)

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -2,6 +2,9 @@ using Colors, FixedPointNumbers, Test
 using InteractiveUtils # for `subtypes`
 
 @testset "Utilities" begin
+    @test Colors.cbrt01(0.6) ≈ cbrt(big"0.6") atol=eps(1.0)
+    @test Colors.cbrt01(0.6f0) === cbrt(0.6f0)
+
     # issue #351
     xs = max.(rand(1000), 1e-4)
     @noinline l_pow_x_y() = for x in xs; x^2.4 end


### PR DESCRIPTION
This makes the cube root to be inlined to make it suitable for vectorization.
This is intended to reduce precompilation problems rather than increase the speed. (cf. #425)

~This also optimizes the `pow5_12(::Float32)`.~ **Edit**: I will separate this into a new PR.