### PR TITLE
Change SVG images in the document to be output as "text/html"

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,10 @@
 using Documenter, Colors
 
 abstract type SVG end
-function Base.show(io::IO, mime::MIME"image/svg+xml", svg::SVG)
+function Base.show(io::IO, ::MIME"text/html", svg::SVG)
+    write(io, "<html><body>")
     write(io, take!(svg.buf))
+    write(io, "</body></html>")
     flush(io)
 end
 


### PR DESCRIPTION
In Documenter.jl v0.27, SVG images ("image/svg+xml") are now embedded using the `<img>` tag.

For example:
Documenter v0.27: https://juliagraphics.github.io/Colors.jl/dev/constructionandconversion/#Available-colorspaces
Documenter v0.26: https://juliagraphics.github.io/Colors.jl/v0.12/constructionandconversion/#Available-colorspaces

This avoids the limitations of the `<img>` tag.
Note that the swatch display which is implemented in Colors.jl uses the `<img>` tag.