### PR TITLE
Use `Float32` to calculate `DE_2000` for low precision colors

### DIFF
--- a/docs/src/colordifferences.md
+++ b/docs/src/colordifferences.md
@@ -4,13 +4,13 @@ The [`colordiff`](@ref) function gives an approximate value for the difference b
 
 ```jldoctest example; setup = :(using Colors)
 julia> colordiff(colorant"red", colorant"darkred")
-23.75414245117878
+23.754143f0
 
 julia> colordiff(colorant"red", colorant"blue")
-52.881355694354724
+52.881363f0
 
 julia> colordiff(HSV(0, 0.75, 0.5), HSL(0, 0.75, 0.5))
-19.485908737785326
+19.48590873778533
 ```
 
 ```julia

--- a/test/colordiff.jl
+++ b/test/colordiff.jl
@@ -1,4 +1,5 @@
 using Colors, Test, FixedPointNumbers
+using Colors: _de2000_t, _de2000_rot
 
 # Test the colordiff function against example input and output from:
 #
@@ -53,7 +54,17 @@ using Colors, Test, FixedPointNumbers
             a64, b64 = Lab(a...), Lab(b...)
             @test colordiff(a64, b64; metric=metric) ≈ dexpect atol=eps_cdiff
             @test colordiff(b64, a64; metric=metric) ≈ dexpect atol=eps_cdiff
+            a32, b32 = Lab{Float32}(a64), Lab{Float32}(b64)
+            @test colordiff(a32, b32; metric=metric) ≈ dexpect atol=eps_cdiff
+            @test colordiff(b32, a32; metric=metric) ≈ dexpect atol=eps_cdiff
         end
+
+        h64 = 0.0:0.1:360.0
+        h32 = 0.0f0:0.1f0:360.0f0
+        @test all(h -> isapprox(_de2000_t(h), _de2000_t(big(h)), atol=3eps(Float64)), h64)
+        @test all(h -> isapprox(_de2000_t(h), _de2000_t(big(h)), atol=2eps(Float32)), h32)
+        @test all(h -> isapprox(_de2000_rot(h), _de2000_rot(big(h)), atol=eps(Float64)), h64)
+        @test all(h -> isapprox(_de2000_rot(h), _de2000_rot(big(h)), atol=eps(Float32)), h32)
     end
 
     jl_red    =    RGB{N0f8}(Colors.JULIA_LOGO_COLORS.red)


### PR DESCRIPTION
This speeds up the calculation of `DE_2000` while ensuring the accuracy of `5e-5`.
This changes not only the type of intermediate variables, but also the return type. (cf. #477)
~This also fixes typos in the `DE_2000` test data.~ (separated to #499)

```julia
julia> a, b = Lab(50, -1.3802, -84.2814), Lab(50, 0.0000, -82.7485);

julia> colordiff(Lab{BigFloat}(a), Lab{BigFloat}(b)) |> Float64
0.9999988647524654

julia> colordiff(Lab{Float64}(a), Lab{Float64}(b))
0.9999988647524661

julia> colordiff(Lab{Float32}(a), Lab{Float32}(b))
1.0000001f0

julia> colordiff(Lab{BigFloat}.(Lab{Float32}.((a, b)))...) |> Float32
0.99999994f0
```

### Benchmark
```julia
julia> a = Lab{Float32}.(rand(RGB{Float32}, 1000, 1000));

julia> b = Lab{Float32}.(rand(RGB{Float32}, 1000, 1000));

julia> @btime colordiff.($a, $b);
  174.563 ms (2 allocations: 7.63 MiB) # v0.12.8 (`Float64`)
   69.342 ms (2 allocations: 3.81 MiB) # this PR (`Float32`)

julia> a64, b64 = Lab{Float64}.(a), Lab{Float64}.(b);

julia> @btime colordiff.($a64, $b64);
  107.792 ms (2 allocations: 7.63 MiB) # this PR

julia> versioninfo()
Julia Version 1.6.2
Commit 1b93d53fc4 (2021-07-14 15:36 UTC)
Platform Info:
  OS: Windows (x86_64-w64-mingw32)
  CPU: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-11.0.1 (ORCJIT, tigerlake)
```