### PR TITLE
Optimize `ColorTypes.hue(c)`

### DIFF
--- a/docs/src/colordifferences.md
+++ b/docs/src/colordifferences.md
@@ -7,7 +7,7 @@ julia> colordiff(colorant"red", colorant"darkred")
 23.75414245117878
 
 julia> colordiff(colorant"red", colorant"blue")
-52.88135569435472
+52.88135569435473
 
 julia> colordiff(HSV(0, 0.75, 0.5), HSL(0, 0.75, 0.5))
 19.485908737785326

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -151,6 +151,49 @@ end
 pow7(x) = (y = x*x*x; y*y*x)
 pow7(x::Integer) = pow7(Float64(x)) # avoid overflow
 
+# TODO: migrate to ColorTypes.jl
+@inline function atan360_kernel(t::Float64)
+    @evalpoly(t^2,
+        0.8952465548919112,  -0.2984155182972285,   0.1790493109637673,   -0.12789236387151418,
+        0.09947179554077099, -0.08138502549008089,  0.06884985860325084,  -0.059532134551367105,
+        0.05164982834653973, -0.042514874197367984, 0.028600080170923112, -0.011001809246782802)
+end
+@inline function atan360_kernel(t::Float32)
+    @evalpoly(t^2,
+        0.89524657f0, -0.2984143f0, 0.17899014f0, -0.12683357f0, 0.090689056f0, -0.045563098f0)
+end
+
+# a variant of `atand` returning the angle in the range of [0, 360]
+atan360(y, x) = (a = atand(y, x); signbit(a) ? oftype(a, a + 360) : a)
+function atan360(y::T, x::T) where T <: Union{Float32, Float64}
+    (isnan(x) | isnan(y)) && return T(NaN)
+    ax, ay = abs(x), abs(y)
+    n, m = @fastmath minmax(ax, ay)
+    if m == T(Inf)
+        d0 = n == T(Inf) ? T(45) : T(0)
+    else
+        m = m == T(0) ? T(0.5) : m
+        ta = (n + n) > m ? T(0.5) : T(0) # 1-step CORDIC
+        # ro=(n + n) > m ? T(atand(0.5) / 64) : T(0)
+        ro = @fastmath max(T(0), ta - T(0.5 - 0.4150789246418436))
+        n1 = n - ta * m
+        m1 = m + ta * n
+        t = n1 / m1 # in [0, 0.5]
+        p = atan360_kernel(t)
+        d0 = muladd(t, p, ro) * T(64)
+    end
+    b1 = T( 90) + flipsign(T( -90), x)
+    b2 = T(180) + flipsign(T(-180), y)
+    d1 = ay > ax ? T(90) - d0 : d0
+    d2 = b1 + flipsign(d1, x) # signbit(x) ? T(180) - d1 : d1
+    dd = b2 + flipsign(d2, y) # signbit(y) ? T(360) - d2 : d2
+    return dd
+end
+
+# override only the `Lab` and `Luv` versions just for now
+ColorTypes.hue(c::Lab) = atan360(c.b, c.a)
+ColorTypes.hue(c::Luv) = atan360(c.v, c.u)
+
 # Linear interpolation in [a, b] where x is in [0,1],
 # or coerced to be if not.
 function lerp(x, a, b)

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -35,6 +35,24 @@ using InteractiveUtils # for `subtypes`
     @test Colors.pow12_5(0.6) ≈ Colors.pow12_5(big"0.6") atol=1e-6
     @test Colors.pow12_5(0.6N0f16) ≈ Colors.pow12_5(big"0.6") atol=1e-6
 
+    # TODO: migrate to ColorTypes.jl
+    @testset "atan360" begin
+        for y in (-Inf, -0.0, +0.0, Inf, NaN), x in (-Inf, -0.0, +0.0, Inf, NaN)
+            z0 = atand(y, x)
+            z = signbit(z0) ? 360 + z0 : z0
+            @test Colors.atan360(y, x) === z
+            @test Colors.atan360(Float32(y), Float32(x)) === Float32(z)
+        end
+        for theta in 0.0:15.0:360.0
+            yf64, xf64 = (sind(theta), cosd(theta)) .* 65.4321
+            ybf, xbf = big(yf64), big(xf64)
+            @test Colors.atan360(yf64, xf64) ≈ Colors.atan360(ybf, xbf) rtol=3eps(Float64)
+            yf32, xf32 = Float32(yf64), Float32(xf64)
+            ybf, xbf = big(yf32), big(xf32)
+            @test Colors.atan360(yf32, xf32) ≈ Colors.atan360(ybf, xbf) rtol=3eps(Float32)
+        end
+    end
+
     @testset "hex" begin
         @test hex(RGB(1,0.5,0)) == "FF8000"
         @test hex(RGBA(1,0.5,0,0.25)) == "FF800040"


### PR DESCRIPTION
The conventional version using `atand` has a larger numerical error because `rad2deg` is applied to the `atan` result.
This improves the accuracy and speed by making the internal representation conform to degrees and by simplifying the handling of exceptional cases.

This change should be made in ColorTypes.jl, but for the convenience of development, it is implemented once in Colors.jl.

```julia
julia> hue(Lab(50, big(50.85106f0), big(-24.293373f0))) |> Float32
334.4645f0

julia> hue(Lab(50, 50.85106f0, -24.293373f0))
334.4645f0

julia> hue(ALab(50, 50.85106f0, -24.293373f0)) # all versions except `Lab` and `Luv` are old at the moment
334.46454f0
```