### PR TITLE
Improve accuracy of `delta_h` for small differences

### DIFF
--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -212,6 +212,11 @@ using InteractiveUtils # for `subtypes`
         @test_throws DomainError Colors.delta_h(LCHab(50, -1f-9, 70), LCHab(50, 60, 70))
         @test @inferred(Colors.delta_h(Lab(50, -10, 10), Lab(50, 10, -10))) ≈ 28.284271f0
         @test @inferred(Colors.delta_h(ALuv(50, 0, 0), ALuv(50, 0, 10))) === 0.0f0
+
+        a, b = Lab(50, 4, 80), Lab(60, 5, 101)
+        @test Colors.delta_h(a, b) ≈ -0.04444444f0 atol = 1f-4
+        dhb = Colors.delta_h(Lab{BigFloat}(a), Lab{BigFloat}(b))
+        @test Colors.delta_h(Lab{Float64}(a), Lab{Float64}(b)) ≈ dhb atol = 1e-13
     end
 
     # test utility function weighted_color_mean


### PR DESCRIPTION
This avoids the loss of significance when the difference in hue is small. (cf. https://github.com/JuliaGraphics/Colors.jl/issues/477#issuecomment-869102943)
This results in a slowdown of `delta_h`, but it is negligible compared to the total cost of `DE_2000`.

This is one of the preparations for PR #494.
```julia
julia> a = Lab(40, 4, 80); b = Lab(50, 5, 101);

julia> Colors.delta_h(a, b)
-0.043853227f0 # master
-0.04444444f0  # this PR

julia> Colors.delta_h(Lab{BigFloat}(a), Lab{BigFloat}(b))
-0.04444444308963756431578907136117476345617361364807484182394389220997687609203497
```