### PR TITLE
Improve accuracy of `delta_h` for large hue differences

### DIFF
--- a/docs/src/colordifferences.md
+++ b/docs/src/colordifferences.md
@@ -7,7 +7,7 @@ julia> colordiff(colorant"red", colorant"darkred")
 23.75414245117878
 
 julia> colordiff(colorant"red", colorant"blue")
-52.88135569435473
+52.881355694354724
 
 julia> colordiff(HSV(0, 0.75, 0.5), HSL(0, 0.75, 0.5))
 19.485908737785326

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -219,6 +219,12 @@ using InteractiveUtils # for `subtypes`
         @test Colors.delta_h(Lab{Float64}(a), Lab{Float64}(b)) ≈ dhb atol = 1e-13
     end
 
+    @testset "delta_c" begin
+        a, b = Lab(50, 40, -31), Lab(90, -30, 41)
+        @test @inferred(Colors.delta_c(a, b)) ≈ -0.19721946f0 atol = 1f-7
+        @test @inferred(Colors.delta_c(LCHab(a), LCHab(b))) ≈ -0.19721946f0 atol = 1f-6
+    end
+
     # test utility function weighted_color_mean
     parametric2 = [GrayA,AGray32,AGray]
     parametric3 = ColorTypes.parametric3


### PR DESCRIPTION
This is a follow-up to PR #501.
This avoids the loss of significance when |Δh| > 90 deg.
This also adds `delta_c` to improve accuracy of `Lab{Float32}` chroma differences.

```julia
julia> a, b = Lab(60, -36.75124f0, -4.8861504f0), Lab(80, 4.557669f0, -2.6522517f0);

julia> Colors.delta_h(a, b)
-26.459148f0 # master
-26.459143f0 # this PR

julia> Colors.delta_h(Lab{BigFloat}(a), Lab{BigFloat}(b))
-26.45914388977270124791437895470628506022253442451544986697371328558951044881593

julia> chroma(a) - chroma(b)
31.801413f0

julia> Colors.delta_c(a, b)
31.801414f0

julia> chroma(Lab{BigFloat}(a)) - chroma(Lab{BigFloat}(b))
31.80141452063303790359376637963574569550424247180931525255208635027325242378461
```