### PR TITLE
Improve accuracy of `mean_hue` for `Lab` and `Luv` colors

### DIFF
--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -200,6 +200,10 @@ using InteractiveUtils # for `subtypes`
         @test @inferred(mean_hue(Lab(50, 0, 10), Lab(50, 10, -10))) === 22.5f0
         @test @inferred(mean_hue(ALuv(50, 0, 0), ALuv(50, 0, 10))) === 90.0f0
 
+        @test @inferred(mean_hue(LCHab(50, 60, 270), LCHab(90, 80, 80))) === 355.0f0
+        @test @inferred(mean_hue(LCHuv(50, 60, 80), LCHuv(90, 0, 70))) === 80.0f0
+        @test @inferred(mean_hue(LCHabA(90.0, 0, 70), LCHabA(50, 60, 80))) === 80.0
+
         @test_throws Exception mean_hue(RGB(0.1, 0.2, 0.3), RGB(0.4, 0.5, 0.6))
         @test_throws Exception mean_hue(LChab(10, 20, 30), LCHuv(10, 20, 30))
     end


### PR DESCRIPTION
This calculates the bisection vector in Cartesian space and then obtains its angle.

~This is still in the idea stage and has not been fully studied for accuracy and speed; I would like to prioritize the merging of PR #494.~
#### Accuracy
|1000000 samples  | mean error | maximum error |
|:----------------|-----------:|--------------:|
|`Float32` before | 6.4e-6 °   | 4.0e-5 °      |
|`Float32` after  | 4.2e-6 °   | 2.3e-5 °      |
|`Float64` before | 12.0e-15 ° | 7.7e-14 °     |
|`Float64` after  | 7.7e-15 °  | 4.4e-14 °     |

#### Speed
Unfortunately, there is little speed improvement.
```julia
julia> a = Lab{Float32}.(rand(RGB{Float32}, 1000, 1000));

julia> b = Lab{Float32}.(rand(RGB{Float32}, 1000, 1000));

julia> @btime colordiff.($a, $b);
  69.342 ms (2 allocations: 3.81 MiB) # before
  67.334 ms (2 allocations: 3.81 MiB) # after
```