### PR TITLE
Optimize `distinguishable_colors`

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -313,11 +313,15 @@ end
 const M_RGB2XYZ = Mat3x3([0.4124564390896921    0.357576077643909  0.18043748326639894
                           0.21267285140562248   0.715152155287818  0.07217499330655958
                           0.019333895582329317  0.119192025881303  0.9503040785363677 ])
+
+function linear_rgb_to_xyz(c::AbstractRGB)
+    @mul3x3 XYZ M_RGB2XYZ red(c) green(c) blue(c)
+end
 function cnvt(::Type{XYZ{T}}, c::AbstractRGB) where T
     r = invert_srgb_compand(red(c))
     g = invert_srgb_compand(green(c))
     b = invert_srgb_compand(blue(c))
-    return @mul3x3 XYZ{T} M_RGB2XYZ r g b
+    @mul3x3 XYZ{T} M_RGB2XYZ r g b
 end
 
 

--- a/test/colormaps.jl
+++ b/test/colormaps.jl
@@ -1,18 +1,27 @@
+using Test, Colors
+
 @testset "Colormaps" begin
-    col = distinguishable_colors(10)
-    @test isconcretetype(eltype(col))
-    local mindiff
-    mindiff = Inf
-    for i = 1:10
-        for j = i+1:10
-            mindiff = min(mindiff, colordiff(col[i], col[j]))
+    @testset "distinguishable_colors" begin
+        cols = distinguishable_colors(10)
+        @test isconcretetype(eltype(cols))
+
+        mindiff = Inf
+        for i = 1:10, j = i+1:10
+            mindiff = min(mindiff, colordiff(cols[i], cols[j]))
         end
+        @test mindiff > 8
+
+        seed = distinguishable_colors(1)
+        @test colordiff(distinguishable_colors(1, seed)[1], seed[1]) == 0.0
+        @test colordiff(distinguishable_colors(1, seed; dropseed=true)[1], seed[1]) > 50
+
+        cols_i = distinguishable_colors(4, LCHab(60, 50, 40), transform=identity,
+                                        lchoices=[40, 60], cchoices=[50], hchoices=[40, 140])
+        cols_p = distinguishable_colors(4, LCHab(60, 50, 40), transform=protanopic,
+                                        lchoices=[40, 60], cchoices=[50], hchoices=[40, 140])
+        @test cols_i[2] ≈ LCHab(40, 50, 140) atol=1f-3 # green
+        @test cols_p[2] ≈ LCHab(40, 50,  40) atol=1f-3 # red
     end
-    @test mindiff > 8
-
-    cols = distinguishable_colors(1)
-    @test colordiff(distinguishable_colors(1, cols; dropseed=true)[1], cols[1]) > 50
-
 
     @test length(colormap("RdBu", 100)) == 100
 


### PR DESCRIPTION
This changes the type used for internal operations from `Lab{Float64}` to `Lab{Float32}`.
This also removes the unnecessary sRGB gamma operations and `deleteat!`.

Note that `@nospecialize` is almost useless because of the keyword arguments.

```julia
julia> @btime distinguishable_colors(10);
  10.832 ms (896527 allocations: 14.88 MiB) # master w/o recompilation
  5.104 ms (50998 allocations: 1.50 MiB)    # master w/ recompilation
  2.675 ms (9070 allocations: 213.08 KiB)   # this PR
```
Closes #477