### PR TITLE
Mitigate inference problems in color conversions

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -5,16 +5,18 @@ function _precompile_()
     pctypes = (Gray, RGB, AGray, GrayA, ARGB, RGBA)  # parametric colors
     cctypes = (Gray24, AGray32, RGB24, ARGB32)       # non-parametric colors
     # conversions
-    ## to RGB
-    for T in eltypes, F in feltypes, C in (HSV,LCHab,LCHuv,Lab,Luv,XYZ)
-        precompile(Tuple{typeof(convert),Type{RGB{T}},C{F}})
+    ## from/to XYZ
+    for T in feltypes, C in (HSV,LCHab,LCHuv,Lab,Luv)
+        precompile(Tuple{typeof(convert),Type{C{T}},XYZ{T}})
+        precompile(Tuple{typeof(convert),Type{XYZ{T}},C{T}})
     end
-    ## to XYZ
-    for T in feltypes, F in feltypes, C in (HSV,LCHab,LCHuv,Lab,Luv,XYZ,RGB)
-        precompile(Tuple{typeof(convert),Type{XYZ{T}},C{F}})
-    end
-    for T in feltypes, F in (N0f8, N0f16)
+    for T in feltypes, F in eltypes
+        precompile(Tuple{typeof(convert),Type{RGB{F}},XYZ{T}})
         precompile(Tuple{typeof(convert),Type{XYZ{T}},RGB{F}})
+    end
+    ## to RGB
+    for T in eltypes, F in feltypes, C in (HSV,LCHab,LCHuv,Lab,Luv)
+        precompile(Tuple{typeof(convert),Type{RGB{T}},C{F}})
     end
     # parse
     precompile(Tuple{typeof(parse),Type{ColorTypes.Colorant},String})
@@ -22,6 +24,8 @@ function _precompile_()
     precompile(Tuple{typeof(parse),Type{RGBA{N0f8}},String})
     # colordiff
     for T in eltypes
+        # Currently, there is a problem with `Float64` related to `cos`/`sin`.
+        T === Float64 && continue
         precompile(Tuple{typeof(colordiff),RGB{T},RGB{T}})
     end
     precompile(Tuple{typeof(colormap),String})

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -93,7 +93,6 @@ pow3_4(x) = (y = @fastmath(sqrt(x)); y*@fastmath(sqrt(y))) # x^(3/4)
 # `pow5_12` is called from `srgb_compand`.
 pow5_12(x) = pow3_4(x) / cbrt(x) # 5/12 == 1/2 + 1/4 - 1/3 == 3/4 - 1/3
 @inline function pow5_12(x::Float64)
-    @noinline _cbrt(x) = cbrt01(x)
     p3_4 = pow3_4(x)
     # x^(-1/6)
     if x < 0.02
@@ -106,7 +105,7 @@ pow5_12(x) = pow3_4(x) / cbrt(x) # 5/12 == 1/2 + 1/4 - 1/3 == 3/4 - 1/3
         t0 = @evalpoly(x, 1.7047813285940905, -3.1261253501167308,
             7.498744828350077, -10.100319516746419, 6.820601476522508, -1.7978894213531524)
     else
-        return p3_4 / _cbrt(x)
+        return p3_4 / cbrt01(x)
     end
     # x^(-1/3)
     t1 = t0 * t0
@@ -164,7 +163,7 @@ end
 
 # a variant of `atand` returning the angle in the range of [0, 360]
 atan360(y, x) = (a = atand(y, x); signbit(a) ? oftype(a, a + 360) : a)
-function atan360(y::T, x::T) where T <: Union{Float32, Float64}
+@inline function atan360(y::T, x::T) where T <: Union{Float32, Float64}
     (isnan(x) | isnan(y)) && return T(NaN)
     ax, ay = abs(x), abs(y)
     n, m = @fastmath minmax(ax, ay)
@@ -190,8 +189,8 @@ function atan360(y::T, x::T) where T <: Union{Float32, Float64}
 end
 
 # override only the `Lab` and `Luv` versions just for now
-ColorTypes.hue(c::Lab) = atan360(c.b, c.a)
-ColorTypes.hue(c::Luv) = atan360(c.v, c.u)
+@inline ColorTypes.hue(c::Lab) = atan360(c.b, c.a)
+@inline ColorTypes.hue(c::Luv) = atan360(c.v, c.u)
 
 @inline function sin_kernel(x::Float64)
     x * @evalpoly(x^2,


### PR DESCRIPTION
This uses the `cnvt` instead of the top-level `convert` when source and destination are both known colors.
This also blocks the propagation of inference failures by adding type assertions to the result of `convert`.
~However, these changes do not solve the essential problem (#496). So, this PR is for reference only, and I have no plans to merge this for now.~
By PR #510, we can see the practical effects, e.g.：
```julia
julia> lchab = rand(LCHab, 1000, 1000);

julia> convert.(RGB{Float64}, lchab); # compilation

julia> @time convert.(RGB{Float64}, lchab);
  0.174340 seconds (4.00 M allocations: 144.959 MiB, 37.16% gc time) # before
  0.137165 seconds (2.00 M allocations: 83.923 MiB, 40.44% gc time)  # after
```
I haven't solved the problem yet, though.