### PR TITLE
Implement `polar_to_cartesian`

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -200,8 +200,7 @@ function MSC(h)
     end
     p, t = pt(h)
 
-    alpha=-sind(h)
-    beta=cosd(h)
+    beta, alpha = polar_to_cartesian(1.0, -h)
 
     # un & vn are calculated based on reference white (D65)
     un, vn = xyz_to_uv(WP_DEFAULT)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -468,8 +468,7 @@ end
 
 
 function cnvt(::Type{Lab{T}}, c::LCHab) where T
-    b, a = c.c .* sincos(deg2rad(c.h))
-    Lab{T}(c.l, a, b)
+    Lab{T}(c.l, polar_to_cartesian(c.c, c.h)...)
 end
 
 
@@ -562,8 +561,7 @@ end
 
 
 function cnvt(::Type{Luv{T}}, c::LCHuv) where T
-    v, u = c.c .* sincos(deg2rad(c.h))
-    Luv{T}(c.l, u, v)
+    Luv{T}(c.l, polar_to_cartesian(c.c, c.h)...)
 end
 
 cnvt(::Type{Luv{T}}, c::Color) where {T} = cnvt(Luv{T}, convert(XYZ{T}, c))

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -53,6 +53,22 @@ using InteractiveUtils # for `subtypes`
         end
     end
 
+    @testset "polar_to_cartesian" begin
+        @test Colors.polar_to_cartesian(50.0, NaN) === (NaN, NaN)
+        @test Colors.polar_to_cartesian(0.0f0, Inf32) === (NaN32, NaN32)
+        @test Float64.(Colors.polar_to_cartesian(big"2.0", big"120.0")) === (-1.0, sqrt(3.0))
+
+        theta = -360.0:15.0:540.0
+        yxbf = [sincos(deg2rad(big(t))) .* 64.5 for t in theta]
+        xyf64 = Colors.polar_to_cartesian.(64.5, theta)
+        xyf32 = Colors.polar_to_cartesian.(64.5f0, Float32.(theta))
+
+        @test all(((a, b),) -> isapprox(a[1], b[2], atol=1e-14) &&
+                               isapprox(a[2], b[1], atol=1e-14), zip(xyf64, yxbf))
+        @test all(((a, b),) -> isapprox(a[1], b[2], atol=1e-6) &&
+                               isapprox(a[2], b[1], atol=1e-6), zip(xyf32, yxbf))
+    end
+
     @testset "hex" begin
         @test hex(RGB(1,0.5,0)) == "FF8000"
         @test hex(RGBA(1,0.5,0,0.25)) == "FF800040"


### PR DESCRIPTION
This adds `sincos360`, the rough equivalent of `sincosd`.
The `sincos360` is less accurate than `sincosd`, but in many cases more accurate than `sincos(deg2rad(x))`.
Also, while `sincosd(Inf)` throws a `DomainError`, `sincos360(Inf)` returns `(NaN, NaN)`.

This is mainly intended to mitigate precompilation and inlining issues. (cf. issue #496)

This might have to be moved to ColorTypes.jl as well as `atan360`. (cf. PR #495) Fortunately, moving those methods to ColorTypes.jl seems to maintain the benefits. However, I'm not sure why the problem occurs with `Base`.