### PR TITLE
Work around #496 for Luv, Lab

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -151,12 +151,12 @@ tritanopic(c::Color)   = tritanopic(c, 1.0)
 # MSC - Most Saturated Colorant for given hue h
 # ---------------------
 
-const LUV_HUE_R = hue(convert(Luv, RGB(1.0, 0.0, 0.0)))
-const LUV_HUE_Y = hue(convert(Luv, RGB(1.0, 1.0, 0.0)))
-const LUV_HUE_G = hue(convert(Luv, RGB(0.0, 1.0, 0.0)))
-const LUV_HUE_C = hue(convert(Luv, RGB(0.0, 1.0, 1.0)))
-const LUV_HUE_B = hue(convert(Luv, RGB(0.0, 0.0, 1.0)))
-const LUV_HUE_M = hue(convert(Luv, RGB(1.0, 0.0, 1.0)))
+const LUV_HUE_R = 12.17397852379156 # hue(convert(Luv, RGB(1.0, 0.0, 0.0)))
+const LUV_HUE_Y = 85.87273351614108 # hue(convert(Luv, RGB(1.0, 1.0, 0.0)))
+const LUV_HUE_G = 127.72355232980077 # hue(convert(Luv, RGB(0.0, 1.0, 0.0)))
+const LUV_HUE_C = 192.17397852379156 # hue(convert(Luv, RGB(0.0, 1.0, 1.0)))
+const LUV_HUE_B = 265.8727335161411 # hue(convert(Luv, RGB(0.0, 0.0, 1.0)))
+const LUV_HUE_M = 307.7235523298008 # hue(convert(Luv, RGB(1.0, 0.0, 1.0)))
 """
     MSC(h)
     MSC(h, l; linear=false)
@@ -259,7 +259,7 @@ function find_maximum_chroma(c::C,
     end
 end
 
-const LAB_HUE_Y = hue(convert(Lab, RGB(1.0, 1.0, 0.0)))
+const LAB_HUE_Y = 102.85123437653252 # hue(convert(Lab, RGB(1.0, 1.0, 0.0)))
 
 function find_maximum_chroma(c::LCHab{T}) where T
     maxc = find_maximum_chroma(c, 0, 135)


### PR DESCRIPTION
This fixes the specific demo in #496. These constants were added in 8f6550dd, but there is nothing wrong with that PR---those should be perfectly reasonable operations to perform during package definition.

The origin of the problem is a julia bug whose identity remains mysterious. Some diagnostics were done in https://github.com/JuliaLang/julia/issues/35972, but this particular case appears to be distinct from the mechanism identified there and has not yet been isolated.  This is a simple workaround. 