### PR TITLE
Fix an ambiguity with AbstractTrees

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,8 +14,9 @@ Reexport = "0.2, 1.0"
 julia = "1"
 
 [extras]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["InteractiveUtils", "Test"]
+test = ["AbstractTrees", "InteractiveUtils", "Test"]

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -6,10 +6,9 @@ struct Mat3x3{T} <: AbstractMatrix{T}
     e::NTuple{9, T}
 end
 Mat3x3(mat::Matrix{T}) where {T} = Mat3x3{T}(Tuple(mat))
+Base.IndexStyle(::Type{<:Mat3x3}) = IndexLinear()
 Base.size(::Mat3x3) = (3, 3)
-Base.getindex(M::Mat3x3{T}, i) where {T} = M.e[i]
-Base.getindex(M::Mat3x3{T}, i::Integer, j::Integer) where {T} = M.e[3j + i - 3]
-Base.getindex(M::Mat3x3, I::CartesianIndex{2}) = getindex(M, I.I...)
+Base.getindex(M::Mat3x3{T}, i::Int) where {T} = M.e[i]
 
 macro mul3x3(C, M, c1, c2, c3)
     esc(quote

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Colors, Test
-@test isempty(detect_ambiguities(Colors, Base, Core))
+@test isempty(detect_ambiguities(Colors))
 
 include("algorithms.jl")
 include("conversion.jl")
@@ -10,3 +10,6 @@ include("din99.jl")
 include("display.jl")
 include("parse.jl")
 include("utilities.jl")
+
+using AbstractTrees
+isempty(detect_ambiguities(Colors))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,4 +12,4 @@ include("parse.jl")
 include("utilities.jl")
 
 using AbstractTrees
-isempty(detect_ambiguities(Colors))
+@test isempty(detect_ambiguities(Colors))


### PR DESCRIPTION
The fix is to adhere more closely to the minimalistic
[AbstractArray interface](https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-array).

Fixes #512