### PR TITLE
Add conversions to and from Oklab and LCHOklab

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -429,9 +429,9 @@ function cnvt(::Type{XYZ{T}}, c::LMS) where T
 end
 
 function cnvt(::Type{XYZ{T}}, c::Oklab) where T
-    lms = @mul3x3 LMS{T} XYZ2LMS_OKLAB_INV c.l c.a c.b
+    lms = @mul3x3 LMS{T} LMSP2OKLAB_INV c.l c.a c.b
     lmsp = LMS{T}([lms.l, lms.m, lms.s].^3...)
-    @mul3x3 XYZ{T} LMSP2OKLAB_INV lmsp.l lmsp.m lmsp.s
+    @mul3x3 XYZ{T} XYZ2LMS_OKLAB_INV lmsp.l lmsp.m lmsp.s
 end
 
 cnvt(::Type{XYZ{T}}, c::LCHOklab) where {T} = cnvt(XYZ{T}, cnvt(Oklab{T}, c))

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -637,7 +637,7 @@ function cnvt(::Type{LCHOklab{T}}, c::Oklab) where T
 end
 
 
-cnvt(::Type{LCHOklab{T}}, c::Color) where {T} = cnvt(LCHOklab{T}, convert(Oklab{T}, c)::Lab{T})
+cnvt(::Type{LCHOklab{T}}, c::Color) where {T} = cnvt(LCHOklab{T}, convert(Oklab{T}, c)::Oklab{T})
 
 
 # Everything to DIN99

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -596,8 +596,8 @@ const LMSP2OKLAB_INV = Mat3x3(inv(Float64.(LMSP2OKLAB)))
 
 function cnvt(::Type{Oklab{T}}, c::XYZ) where T
     lms = @mul3x3 LMS{T} XYZ2LMS_OKLAB c.x c.y c.z
-    lms.l, lms.m, lms.s = cbrt01.([lms.l, lms.m, lms.s])
-    @mul3x3 Oklab{T} LMSP2OKLAB lms.l lms.m lms.s
+    lmsp = LMS{T}(cbrt01.([lms.l, lms.m, lms.s])...)
+    @mul3x3 Oklab{T} LMSP2OKLAB lmsp.l lmsp.m lmsp.s
 end
 
 function cnvt(::Type{Oklab{T}}, c::LCHOklab) where T


### PR DESCRIPTION
Currently failing as the type doesn’t exist yet.

To and from XYZ, everything else through XYZ.

I’m using the original specifications provided here: https://bottosson.github.io/posts/oklab/

This is my first contribution to Julia, or any software package for that matter, so any help would be greatly appreciated. For example, should I also add this to the docs?

See also https://github.com/JuliaGraphics/ColorTypes.jl/pull/271