### PR TITLE
Fixed tritanopia simulation

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -135,7 +135,7 @@ function tritanopic(q::T, p, neutral::LMS) where T <: Color
 
     q = LMS(q.l,
             q.m,
-            (one(p) - p) * q.l + p * (-(a*q.l + b*q.m)/c))
+            (one(p) - p) * q.s + p * (-(a*q.l + b*q.m)/c))
     convert(T, q)
 end
 

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -55,4 +55,10 @@ using Test, Colors
     # yellow in LCHab
     @test Colors.find_maximum_chroma(LCHab(94.2, 0, 100)) ≈ 93.749 atol=0.01
     @test Colors.find_maximum_chroma(LCHab(97.6, 0, 105)) ≈ 68.828 atol=0.01
+
+    # Color vision deficiency simulations at p=0
+    rgb = RGB(0.44, 0.26, 0.8)
+    @test protanopic(rgb, 0) .≈ rgb
+    @test deuteranopic(rgb, 0) .≈ rgb
+    @test tritanopic(rgb, 0) .≈ rgb
 end


### PR DESCRIPTION
Summary: Fixed a typo causing incorrect simulation of tritanopic color vision deficiencies. Also added tests for this corrected behavior.

This is my first pull request, I apologize if I have done anything incorrectly. I have been working with simulating various color vision deficiencies, and I noticed that the simulation for tritanopia was not producing results that I expected. Looking into the code in the function `tritanopic` had a typo:

https://github.com/JuliaGraphics/Colors.jl/blob/b550b7bc2f6f27fdf61c30b3215b28df826ceebf/src/algorithms.jl#L138

It should be:

```julia
(one(p) - p) * q.s + p * (-(a*q.l + b*q.m)/c))
```

This error can be easily observed when inspecting the behavior of the function at p=0 (no photopigment loss):

<img width="491" alt="Screen Shot 2022-09-30 at 13 20 03" src="https://user-images.githubusercontent.com/38541020/193351236-aa34b27d-4309-4e2d-b770-888157681b19.png">

This can also be seen in the RGB values:
```julia
rgb = RGB(0.44, 0.26, 0.8)
rgb |> dump
tritanopic(rgb, 0) |> dump
```
```
RGB{Float64}
  r: Float64 0.44
  g: Float64 0.26
  b: Float64 0.8
RGB{Float64}
  r: Float64 0.4547022003851215
  g: Float64 0.2596348656158941
  b: Float64 0.33903165107645483
```

As a counterexample, the function `protanopic` is working correctly:

<img width="492" alt="Screen Shot 2022-09-30 at 13 20 51" src="https://user-images.githubusercontent.com/38541020/193351387-7b5530bf-8030-4857-a830-f47104ecda5d.png">

```julia
rgb = RGB(0.44, 0.26, 0.8)
rgb |> dump
protanopic(rgb, 0) |> dump
```
```
RGB{Float64}
  r: Float64 0.44
  g: Float64 0.26
  b: Float64 0.8
RGB{Float64}
  r: Float64 0.4400000030003578
  g: Float64 0.26000003129854465
  b: Float64 0.8000000074911268
```

This pull request fixes this typo, and adds three tests to validate this correct behavior. Please let me know if there are any questions.
