### PR TITLE
Switch to SnoopPrecompile

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,11 +6,13 @@ version = "0.13.0-dev"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 
 [compat]
 ColorTypes = "0.10, 0.11"
 FixedPointNumbers = "0.6, 0.7, 0.8"
 Reexport = "0.2, 1.0"
+SnoopPrecompile = "1"
 julia = "1"
 
 [extras]

--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -47,7 +47,6 @@ const JULIA_LOGO_COLORS = (red = RGB{N0f8}(0.796, 0.235, 0.2),  # colorant"#cb3c
 
 if VERSION >= v"1.1"   # work around https://github.com/JuliaLang/julia/issues/34121
     include("precompile.jl")
-    _precompile_()
 end
 
 end # module

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,34 +1,39 @@
-function _precompile_()
-    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+using SnoopPrecompile
+
+@precompile_setup begin
     eltypes = (N0f8, N0f16, Float32, Float64)        # eltypes of parametric colors
     feltypes = (Float32, Float64)                    # floating-point eltypes
     pctypes = (Gray, RGB, AGray, GrayA, ARGB, RGBA)  # parametric colors
     cctypes = (Gray24, AGray32, RGB24, ARGB32)       # non-parametric colors
-    # conversions
-    ## from/to XYZ
-    for T in feltypes, C in (HSV,LCHab,LCHuv,Lab,Luv)
-        precompile(Tuple{typeof(convert),Type{C{T}},XYZ{T}})
-        precompile(Tuple{typeof(convert),Type{XYZ{T}},C{T}})
+    @precompile_all_calls begin
+        # conversions
+        ## from/to XYZ
+        for T in feltypes, C in (HSV,LCHab,LCHuv,Lab,Luv)
+            convert(C{T}, zero(XYZ{T}))
+            convert(XYZ{T}, zero(C{T}))
+        end
+        for T in feltypes, F in eltypes
+            convert(RGB{F}, zero(XYZ{T}))
+            convert(XYZ{T}, zero(RGB{F}))
+        end
+        ## to RGB
+        for T in eltypes, F in feltypes, C in (HSV,LCHab,LCHuv,Lab,Luv)
+            convert(RGB{T}, zero(C{F}))
+        end
+        # parse
+        for str in ("red", "#D0FF58")
+            parse(ColorTypes.Colorant, str)
+            parse(RGB{N0f8}, str)
+            parse(RGBA{N0f8}, str)
+        end
+        # colordiff
+        for T in eltypes
+            # Currently, there is a problem with `Float64` related to `cos`/`sin`.
+            T === Float64 && continue
+            colordiff(zero(RGB{T}), zero(RGB{T}))
+        end
+        colormap("Blues")
+        colormap("Blues", 10; logscale=true)
+        distinguishable_colors(5)
     end
-    for T in feltypes, F in eltypes
-        precompile(Tuple{typeof(convert),Type{RGB{F}},XYZ{T}})
-        precompile(Tuple{typeof(convert),Type{XYZ{T}},RGB{F}})
-    end
-    ## to RGB
-    for T in eltypes, F in feltypes, C in (HSV,LCHab,LCHuv,Lab,Luv)
-        precompile(Tuple{typeof(convert),Type{RGB{T}},C{F}})
-    end
-    # parse
-    precompile(Tuple{typeof(parse),Type{ColorTypes.Colorant},String})
-    precompile(Tuple{typeof(parse),Type{RGB{N0f8}},String})
-    precompile(Tuple{typeof(parse),Type{RGBA{N0f8}},String})
-    # colordiff
-    for T in eltypes
-        # Currently, there is a problem with `Float64` related to `cos`/`sin`.
-        T === Float64 && continue
-        precompile(Tuple{typeof(colordiff),RGB{T},RGB{T}})
-    end
-    precompile(Tuple{typeof(colormap),String})
-    precompile(Tuple{typeof(colormap),String,Int})
-    precompile(Tuple{typeof(distinguishable_colors),Int})
 end


### PR DESCRIPTION
On my machine, the workload inside the `@precompile_all_calls`
goes from 0.3s with the previous precompile script to 0.08s with the new
one, a 4x reduction. Given that we don't have precompiles anymore in
ColorTypes (see https://github.com/JuliaGraphics/ColorTypes.jl/issues/270,
a decision I agree with), this package seems like a good place to have
some.