### PR TITLE
Fix name collision in document examples

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,7 @@ makedocs(
     clean = false,
     modules = [Colors],
     format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true",
+                             size_threshold = nothing,
                              assets = ["assets/resize_svg.js", "assets/favicon.ico"]),
     checkdocs = :exports,
     sitename = "Colors",

--- a/docs/src/constructionandconversion.md
+++ b/docs/src/constructionandconversion.md
@@ -116,10 +116,10 @@ You can convert colors to hexadecimal strings using the [`hex`](@ref) function.
 Note that the conversion result does not have the prefix `"#"`.
 
 ```jldoctest example
-julia> color = colorant"#C0FFEE"
+julia> col = colorant"#C0FFEE"
 RGB{N0f8}(0.753,1.0,0.933)
 
-julia> hex(color)
+julia> hex(col)
 "C0FFEE"
 ```
 


### PR DESCRIPTION
cf. #522 