### PR TITLE
Backport "Change SVG images in the document to be output as "text/html" (#490)"

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,10 @@
 using Documenter, Colors
 
 abstract type SVG end
-function Base.show(io::IO, mime::MIME"image/svg+xml", svg::SVG)
+function Base.show(io::IO, ::MIME"text/html", svg::SVG)
+    write(io, "<html><body>")
     write(io, take!(svg.buf))
+    write(io, "</body></html>")
     flush(io)
 end
 


### PR DESCRIPTION
Fixes #554