### PR TITLE
Remove deprecated bindings RGB4 RGB1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-ColorTypes = "0.11.5"
+ColorTypes = "0.12"
 FixedPointNumbers = "0.6, 0.7, 0.8"
 Reexport = "0.2, 1.0"
 julia = "1"

--- a/src/Colors.jl
+++ b/src/Colors.jl
@@ -4,8 +4,10 @@ using FixedPointNumbers
 using Reexport
 
 @reexport using ColorTypes
-Base.@deprecate_binding RGB1 XRGB
-Base.@deprecate_binding RGB4 RGBX
+# remove deprecated bindings 
+# see discussion https://github.com/JuliaIO/ImageMagick.jl/issues/235
+# Base.@deprecate_binding RGB1 XRGB
+# Base.@deprecate_binding RGB4 RGBX
 
 
 import Base: ==, +, -, *, /

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -72,6 +72,9 @@ cnvt(::Type{C}, c) where {C} = convert(C, convert(RGB{eltype(C)}, c)::RGB{eltype
 
 # Conversions from grayscale
 # --------------------------
+function ColorTypes._convert(::Type{Cdest}, ::Type{O}, ::Type{O}, g) where {Cdest<:Color,O<:AbstractGray}
+    cnvt(Cdest, g)
+end
 function ColorTypes._convert(::Type{Cdest}, ::Type{Odest}, ::Type{Osrc}, g) where {Cdest<:Color,Odest,Osrc<:AbstractGray}
     cnvt(Cdest, convert(RGB{eltype(Cdest)}, g))
 end


### PR DESCRIPTION
This removes the deprecated bindings for RGB4 and RGB1, see discussion:

https://github.com/JuliaIO/ImageMagick.jl/issues/235
and similar fix in ColorTypes.jl
https://github.com/JuliaGraphics/ColorTypes.jl/pull/312

It also requires the new version of ColorTypes in Compat, but that will cause failures until that version is registered. 

CC: @ViralBShah, @ararslan

