### PR TITLE
Update doc formatting to Julia 1.10

### DIFF
--- a/.github/workflows/Documentations.yml
+++ b/.github/workflows/Documentations.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1'
+          version: 'lts'
       - uses: julia-actions/cache@v2
       - name: Configure doc environment
         shell: julia --project=docs --color=yes {0}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs/build/
 docs/site/
 .DS_Store
 /docs/Manifest.toml
+Manifest.toml

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,3 +3,7 @@ Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+
+[compat]
+Documenter = "1"
+Base64 = "1"

--- a/docs/src/colordifferences.md
+++ b/docs/src/colordifferences.md
@@ -2,7 +2,7 @@
 
 The [`colordiff`](@ref) function gives an approximate value for the difference between two colors.
 
-```jldoctest example; setup = :(using Colors)
+```jldoctest example; setup = :(using Colors), filter = r"19.4859087377853\d*" => s"19.48590873778533"
 julia> colordiff(colorant"red", colorant"darkred")
 23.754143f0
 

--- a/docs/src/colormapsandcolorscales.md
+++ b/docs/src/colormapsandcolorscales.md
@@ -17,30 +17,30 @@ to `stop`, inclusive, returning an `Array` of colors.
 julia> using Colors
 
 julia> c1 = colorant"red"
-RGB{N0f8}(1.0,0.0,0.0)
+RGB{N0f8}(1.0, 0.0, 0.0)
 
 julia> c2 = colorant"green"
-RGB{N0f8}(0.0,0.502,0.0)
+RGB{N0f8}(0.0, 0.502, 0.0)
 
 julia> range(c1, stop=c2, length=15)
-15-element Array{RGB{N0f8},1} with eltype RGB{FixedPointNumbers.N0f8}:
- RGB{N0f8}(1.0,0.0,0.0)
- RGB{N0f8}(0.929,0.035,0.0)
- RGB{N0f8}(0.859,0.071,0.0)
- RGB{N0f8}(0.784,0.106,0.0)
- RGB{N0f8}(0.714,0.145,0.0)
- RGB{N0f8}(0.643,0.18,0.0)
- RGB{N0f8}(0.573,0.216,0.0)
- RGB{N0f8}(0.502,0.251,0.0)
- RGB{N0f8}(0.427,0.286,0.0)
- RGB{N0f8}(0.357,0.322,0.0)
- RGB{N0f8}(0.286,0.357,0.0)
- RGB{N0f8}(0.216,0.396,0.0)
- RGB{N0f8}(0.141,0.431,0.0)
- RGB{N0f8}(0.071,0.467,0.0)
- RGB{N0f8}(0.0,0.502,0.0)
+15-element Vector{RGB{FixedPointNumbers.N0f8}}:
+ RGB(1.0, 0.0, 0.0)
+ RGB(0.929, 0.035, 0.0)
+ RGB(0.859, 0.071, 0.0)
+ RGB(0.784, 0.106, 0.0)
+ RGB(0.714, 0.145, 0.0)
+ RGB(0.643, 0.18, 0.0)
+ RGB(0.573, 0.216, 0.0)
+ RGB(0.502, 0.251, 0.0)
+ RGB(0.427, 0.286, 0.0)
+ RGB(0.357, 0.322, 0.0)
+ RGB(0.286, 0.357, 0.0)
+ RGB(0.216, 0.396, 0.0)
+ RGB(0.141, 0.431, 0.0)
+ RGB(0.071, 0.467, 0.0)
+ RGB(0.0, 0.502, 0.0)
 ```
-If you use Julia through Juno or IJulia, you can get the following color swatches.
+If you use Julia through VSCode or IJulia, you can get the following color swatches.
 ```@example range
 using Colors # hide
 showable(::MIME"text/plain", ::AbstractVector{C}) where {C<:Colorant} = false # hide
@@ -73,7 +73,7 @@ For example:
 
 ```jldoctest example
 julia> weighted_color_mean(0.8, colorant"red", colorant"green")
-RGB{N0f8}(0.8,0.102,0.0)
+RGB{N0f8}(0.8, 0.102, 0.0)
 ```
 You can also get the weighted mean of three or more colors by passing the
 collections of weights and colors. The following is an example of bilinear

--- a/docs/src/constructionandconversion.md
+++ b/docs/src/constructionandconversion.md
@@ -63,37 +63,37 @@ using the [`@colorant_str`](@ref) macro and the [`parse`](@ref) function.
 julia> using Colors
 
 julia> colorant"red" # named color
-RGB{N0f8}(1.0,0.0,0.0)
+RGB{N0f8}(1.0, 0.0, 0.0)
 
 julia> parse(Colorant, "DeepSkyBlue") # color names are case-insensitive
-RGB{N0f8}(0.0,0.749,1.0)
+RGB{N0f8}(0.0, 0.749, 1.0)
 
 julia> colorant"#FF0000" # 6-digit hex notation
-RGB{N0f8}(1.0,0.0,0.0)
+RGB{N0f8}(1.0, 0.0, 0.0)
 
 julia> colorant"#f00" # 3-digit hex notation
-RGB{N0f8}(1.0,0.0,0.0)
+RGB{N0f8}(1.0, 0.0, 0.0)
 
 julia> colorant"rgb(255,0,0)" # rgb() notation with integers in [0, 255]
-RGB{N0f8}(1.0,0.0,0.0)
+RGB{N0f8}(1.0, 0.0, 0.0)
 
 julia> colorant"rgba(255,0,0,0.6)" # with alpha in [0, 1]
-RGBA{N0f8}(1.0,0.0,0.0,0.6)
+RGBA{N0f8}(1.0, 0.0, 0.0, 0.6)
 
 julia> colorant"rgba(100%,80%,0.0%,0.6)" # with percentages
-RGBA{N0f8}(1.0,0.8,0.0,0.6)
+RGBA{N0f8}(1.0, 0.8, 0.0, 0.6)
 
 julia> parse(ARGB, "rgba(255,0,0,0.6)") # you can specify the return type
-ARGB{N0f8}(1.0,0.0,0.0,0.6)
+ARGB{N0f8}(1.0, 0.0, 0.0, 0.6)
 
 julia> colorant"hsl(120, 100%, 25%)" # hsl() notation
-HSL{Float32}(120.0f0,1.0f0,0.25f0)
+HSL{Float32}(120.0, 1.0, 0.25)
 
 julia> colorant"hsla(120, 100%, 25%, 60%)" # hsla() notation
-HSLA{Float32}(120.0f0,1.0f0,0.25f0,0.6f0)
+HSLA{Float32}(120.0, 1.0, 0.25, 0.6)
 
 julia> colorant"transparent" # transparent "black"
-RGBA{N0f8}(0.0,0.0,0.0,0.0)
+RGBA{N0f8}(0.0, 0.0, 0.0, 0.0)
 ```
 
 All CSS/SVG named colors are supported, in addition to X11 named colors, when their definitions do not clash with SVG.
@@ -110,12 +110,12 @@ colors can be converted to `RGB{N0f16}` (for example) using:
 julia> using FixedPointNumbers
 
 julia> RGB{N0f16}(colorant"indianred")
-RGB{N0f16}(0.80392,0.36078,0.36078)
+RGB{N0f16}(0.80392, 0.36078, 0.36078)
 ```
 or
 ```jldoctest example
 julia> parse(RGB{N0f16}, "indianred")
-RGB{N0f16}(0.80392,0.36078,0.36078)
+RGB{N0f16}(0.80392, 0.36078, 0.36078)
 ```
 
 
@@ -124,7 +124,7 @@ Note that the conversion result does not have the prefix `"#"`.
 
 ```jldoctest example
 julia> col = colorant"#C0FFEE"
-RGB{N0f8}(0.753,1.0,0.933)
+RGB{N0f8}(0.753, 1.0, 0.933)
 
 julia> hex(col)
 "C0FFEE"
@@ -138,10 +138,10 @@ For example:
 
 ```jldoctest example
 julia> convert(RGB, HSL(270, 0.5, 0.5)) # without the element type
-RGB{Float64}(0.5,0.25,0.75)
+RGB{Float64}(0.5, 0.25, 0.75)
 
 julia> convert(RGB{N0f8}, HSL(270, 0.5, 0.5)) # with the element type
-RGB{N0f8}(0.502,0.251,0.749)
+RGB{N0f8}(0.502, 0.251, 0.749)
 ```
 
 Depending on the source and destination colorspace, this may not be perfectly lossless.
@@ -152,13 +152,13 @@ Colors.jl allows you to convert colors to transparent or opaque types.
 
 ```jldoctest example
 julia> col = colorant"yellow"
-RGB{N0f8}(1.0,1.0,0.0)
+RGB{N0f8}(1.0, 1.0, 0.0)
 
 julia> transparent = alphacolor(col, 0.5)  # or coloralpha(col)
-ARGB{N0f8}(1.0,1.0,0.0,0.502)
+ARGB{N0f8}(1.0, 1.0, 0.0, 0.502)
 
 julia> opaque = color(transparent)
-RGB{N0f8}(1.0,1.0,0.0)
+RGB{N0f8}(1.0, 1.0, 0.0)
 ```
 
 ---

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -508,10 +508,10 @@ This is semantically equivalent to the calculation of `sum(weights .* colors)`.
 julia> rgbs = (RGB(1, 0, 0), RGB(0, 1, 0), RGB(0, 0, 1));
 
 julia> weighted_color_mean([0.2, 0.2, 0.6], rgbs)
-RGB{N0f8}(0.2,0.2,0.6)
+RGB{N0f8}(0.2, 0.2, 0.6)
 
 julia> weighted_color_mean(0.5:-0.25:0.0, RGB{Float64}.(rgbs))
-RGB{Float64}(0.5,0.25,0.0)
+RGB{Float64}(0.5, 0.25, 0.0)
 ```
 
 !!! compat "Colors v0.13"


### PR DESCRIPTION
Julia has periodically changed its print formatting. This updates to
Julia 1.10, although the doctests also pass on Julia 1.11. doctests
won't pass on old versions of Julia, but since 1.10 is the new LTS it
makes sense for this to be the default.

Also:
- explicitly use `lts` in the documentation workflow
- add `[compat]` in `docs/Project.toml`
- adjust for differences in CPU rounding in doctests
- fix an outdated reference to Juno