### PR TITLE
add `LinearAlgebra` to `deps`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.13.1"
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1,3 +1,5 @@
+using LinearAlgebra
+
 # Conversions
 # -----------
 


### PR DESCRIPTION
`Colors.jl` use `LinearAlgebra`, but doesn't include it in `deps`.

It would cause an error when using `PackageCompiler.jl`. The error message is:

```
ERROR: LoadError: MethodError: no method matching inv(::Matrix{Float64})
The function `inv` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  inv(::ComplexF64)
   @ Base complex.jl:479
  inv(::BigFloat)
   @ Base mpfr.jl:678
  inv(::Missing)
   @ Base missing.jl:101
  ...

Stacktrace:
 [1] top-level scope
   @ ~/.julia/packages/Colors/VFEJ1/src/conversions.jl:616
 [2] top-level scope
   @ ~/.julia/packages/Colors/VFEJ1/src/Colors.jl:30
 [3] top-level scope
   @ stdin:5
```